### PR TITLE
Add bilingual README with project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+[English](#english) | [中文](#中文)
+
+## English
+
+**Awesome Prompts** is a curated collection of prompts for large language and multi‑modal models. The prompts are organized by modality and task type, covering text‑to‑text, text‑to‑image, and text‑to‑video scenarios.
+
+For a richer reading experience and the full prompt library, visit [prmbr.com](https://prmbr.com/).
+
+## 中文
+
+**精选提示词库** 收录了面向大语言模型和多模态模型的各类提示词，并按模态与任务类型分类，包括文本生成、文生图、文生视频等情境。
+
+为了获得更好的阅读体验和完整的提示词库，请访问 [prmbr.com](https://prmbr.com/)。
+


### PR DESCRIPTION
## Summary
- add README with English and Chinese sections describing the goal of the prompt collection
- include quick links and a pointer to [prmbr.com](https://prmbr.com/) for the full site

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68bda80595f48333ab9789c7bb4968d2