### PR TITLE
Link homepage items to relevant docs

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -5,18 +5,18 @@ Welcome to **Awesome Prompts**. The collection is organized by modality and task
 ## 📂 Modalities & Categories
 
 ### 📝 Text-to-Text
-- Programming
-- Content Creation
-- Role Play
-- Archives
+- [Programming](text-to-text/programming/javascript-console.md)
+- [Content Creation](text-to-text/content-creation/advertising-campaign.md)
+- [Role Play](text-to-text/role-play/therapist-session.md)
+- [Archives](text-to-text/archives/awesome-chatgpt-prompts.en.md)
 
 ### 🎨 Text-to-Image
-- General examples
-- Nano Banana cases
-- GPT cases
+- [General examples](text-to-image/cyberpunk-city.md)
+- [Nano Banana cases](text-to-image/nano-banana/awesome-nano-banana-images.en.md)
+- [GPT cases](text-to-image/gpt/awesome-gpt4o-images.en.md)
 
 ### 🎬 Text-to-Video
-- Sample prompts
+- [Sample prompts](text-to-video/cinematic-trailer.md)
 
 Use the navigation sidebar to explore individual prompts.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,18 +5,18 @@
 ## 📂 模态与分类
 
 ### 📝 文本生成 (Text-to-Text)
-- 编程开发
-- 内容创作
-- 角色扮演
-- 历史归档
+- [编程开发](text-to-text/programming/javascript-console.md)
+- [内容创作](text-to-text/content-creation/advertising-campaign.md)
+- [角色扮演](text-to-text/role-play/therapist-session.md)
+- [历史归档](text-to-text/archives/awesome-chatgpt-prompts.md)
 
 ### 🎨 文生图 (Text-to-Image)
-- 通用示例
-- Nano Banana 案例
-- GPT 案例
+- [通用示例](text-to-image/cyberpunk-city.md)
+- [Nano Banana 案例](text-to-image/nano-banana/awesome-nano-banana-images.md)
+- [GPT 案例](text-to-image/gpt/awesome-gpt4o-images.md)
 
 ### 🎬 文生视频 (Text-to-Video)
-- 示例集合
+- [示例集合](text-to-video/cinematic-trailer.md)
 
 浏览左侧导航以查看具体提示词。
 


### PR DESCRIPTION
## Summary
- link Chinese homepage categories to their corresponding documentation pages
- link English homepage categories to their corresponding documentation pages

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68bdb61b25c48333b2d7a14e511f4921