### PR TITLE
feat: add code block wrap and copy

### DIFF
--- a/docs/stylesheets/code.css
+++ b/docs/stylesheets/code.css
@@ -1,0 +1,5 @@
+/* Wrap lines in code blocks and allow copy button compatibility */
+.md-typeset pre > code {
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ theme:
   logo: assets/logo.svg
   favicon: assets/favicon.ico
   features:
+    - content.code.copy           # 代码块一键复制
     - navigation.instant          # 即时加载
     - navigation.instant.prefetch # 即时预取
     - navigation.instant.progress # 进度指示器
@@ -69,6 +70,8 @@ theme:
     - search.share                # 搜索共享
   icon:
     repo: fontawesome/brands/github
+extra_css:
+  - stylesheets/code.css
 extra:
   analytics:
     provider: google


### PR DESCRIPTION
## Summary
- enable one-click copy buttons for code blocks
- wrap long code lines using custom stylesheet

## Testing
- `pip install -r requirements.txt`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68be9a8037608333b117167a1833ec42