### PR TITLE
Update homepage counts and ordering

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -5,20 +5,20 @@ Welcome to **Awesome Prompts**. The collection is organized by modality and task
 ## 📂 Modalities & Categories
 
 ### 📝 Text-to-Text
-- [Programming](text-to-text/programming/javascript-console.md)
-- [Content Creation](text-to-text/content-creation/advertising-campaign.md)
+- [Archives (222+examples)](text-to-text/archives/awesome-chatgpt-prompts.en.md)
 - [Role Play & Professional roles (ZH) (41+examples)](text-to-text/role-play/professional-roles.md)
 - [Tool & Skills (ZH) (40+examples)](text-to-text/tool-skills.md)
-- [Games & Entertainment (ZH)](text-to-text/game-entertainment.md)
-- [Academic Writing (ZH) (18+examples)](text-to-text/academic-writing.md)
 - [Examples (ZH) (40+examples)](text-to-text/examples.md)
-- [Archives (222+examples)](text-to-text/archives/awesome-chatgpt-prompts.en.md)
+- [Academic Writing (ZH) (18+examples)](text-to-text/academic-writing.md)
+- [Games & Entertainment (ZH)](text-to-text/game-entertainment.md)
+- [Programming](text-to-text/programming/javascript-console.md)
+- [Content Creation](text-to-text/content-creation/advertising-campaign.md)
 
 ### 🎨 Text-to-Image
-- [General examples](text-to-image/cyberpunk-city.md)
-- [Nano Banana cases (51+examples)](text-to-image/nano-banana/awesome-nano-banana-images.en.md)
 - [GPT cases (100+examples)](text-to-image/gpt/awesome-gpt4o-images.en.md)
-- [Illustration prompt tips (24+examples)](text-to-image/ai-prompt-guide.md)
+- [Nano Banana cases (73+examples)](text-to-image/nano-banana/awesome-nano-banana-images.en.md)
+- [Illustration prompt tips (11+tips)](text-to-image/ai-prompt-guide.md)
+- [General examples](text-to-image/cyberpunk-city.md)
 
 ### 🎬 Text-to-Video
 - [Sample prompts](text-to-video/cinematic-trailer.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,20 +5,20 @@
 ## 📂 模态与分类
 
 ### 📝 文本生成 (Text-to-Text)
-- [编程开发](text-to-text/programming/javascript-console.md)
-- [内容创作](text-to-text/content-creation/advertising-campaign.md)
+- [历史归档（222+实例）](text-to-text/archives/awesome-chatgpt-prompts.md)
 - [角色扮演与职业角色篇（41+实例）](text-to-text/role-play/professional-roles.md)
 - [工具技能篇（40+实例）](text-to-text/tool-skills.md)
-- [游戏娱乐篇](text-to-text/game-entertainment.md)
-- [学术论文篇（18+实例）](text-to-text/academic-writing.md)
 - [实例（40+实例）](text-to-text/examples.md)
-- [历史归档（222+实例）](text-to-text/archives/awesome-chatgpt-prompts.md)
+- [学术论文篇（18+实例）](text-to-text/academic-writing.md)
+- [游戏娱乐篇](text-to-text/game-entertainment.md)
+- [编程开发](text-to-text/programming/javascript-console.md)
+- [内容创作](text-to-text/content-creation/advertising-campaign.md)
 
 ### 🎨 文生图 (Text-to-Image)
-- [通用示例](text-to-image/cyberpunk-city.md)
-- [Nano Banana 案例（51+实例）](text-to-image/nano-banana/awesome-nano-banana-images.md)
 - [GPT 案例（100+实例）](text-to-image/gpt/awesome-gpt4o-images.md)
-- [AI 绘画提示要点（24+实例）](text-to-image/ai-prompt-guide.md)
+- [Nano Banana 案例（73+实例）](text-to-image/nano-banana/awesome-nano-banana-images.md)
+- [AI 绘画提示要点（11+要点）](text-to-image/ai-prompt-guide.md)
+- [通用示例](text-to-image/cyberpunk-city.md)
 
 ### 🎬 文生视频 (Text-to-Video)
 - [示例集合](text-to-video/cinematic-trailer.md)


### PR DESCRIPTION
## Summary
- refresh the Chinese homepage to display the latest prompt counts and order categories by collection size
- update the English homepage with the same counts and ordering so both locales stay in sync
- make high-volume prompt collections easier to discover by moving them to the top of each section

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d55a39bfa083338b038a400c08a5f1