### PR TITLE
Add sidebar AdSense slot for home and Nano Banana pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,17 +2,6 @@
 
 欢迎来到 **精选提示词库**，本项目按模态和任务类型整理常用提示词，并提供多语言支持。
 
-<!-- prmbr-horizon -->
-<ins class="adsbygoogle"
-     style="display:block"
-     data-ad-client="ca-pub-7296634171837358"
-     data-ad-slot="2056784980"
-     data-ad-format="auto"
-     data-full-width-responsive="true"></ins>
-<script>
-     (adsbygoogle = window.adsbygoogle || []).push({});
-</script>
-
 ## 📂 模态与分类
 
 ### 📝 文本生成 (Text-to-Text)

--- a/docs/stylesheets/ads.css
+++ b/docs/stylesheets/ads.css
@@ -1,0 +1,13 @@
+.md-ad-slot {
+  margin-top: 1.5rem;
+}
+
+.md-sidebar--secondary .md-ad-slot {
+  max-width: 100%;
+}
+
+@media (max-width: 959px) {
+  .md-ad-slot {
+    display: none;
+  }
+}

--- a/docs/text-to-image/nano-banana/awesome-nano-banana-images.md
+++ b/docs/text-to-image/nano-banana/awesome-nano-banana-images.md
@@ -17,17 +17,6 @@ tags:
 
 喜欢就点 ⭐ Star 收藏起来吧！
 
-<!-- prmbr-horizon -->
-<ins class="adsbygoogle"
-     style="display:block"
-     data-ad-client="ca-pub-7296634171837358"
-     data-ad-slot="2056784980"
-     data-ad-format="auto"
-     data-full-width-responsive="true"></ins>
-<script>
-     (adsbygoogle = window.adsbygoogle || []).push({});
-</script>
-
 ## 🖼️ 例子
 
 <!-- 例 1: 插画变手办（by @ZHO_ZHO_ZHO） -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ theme:
     repo: fontawesome/brands/github
 extra_css:
   - stylesheets/code.css
+  - stylesheets/ads.css
 extra:
   analytics:
     provider: google

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -22,3 +22,49 @@
   ></script>
 {% endblock %}
 
+{% block right %}
+  {{ super() }}
+  {% if page and page.file and page.file.src_path in [
+    "index.md",
+    "text-to-image/nano-banana/awesome-nano-banana-images.md"
+  ] %}
+    <aside class="md-ad-slot">
+      <ins class="adsbygoogle"
+        style="display:block"
+        data-ad-client="ca-pub-7296634171837358"
+        data-ad-slot="2056784980"
+        data-ad-format="auto"
+        data-full-width-responsive="true"></ins>
+    </aside>
+  {% endif %}
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    if (typeof document$ !== "undefined") {
+      document$.subscribe(function () {
+        var slots = document.querySelectorAll(".md-ad-slot ins.adsbygoogle");
+        if (!slots.length) {
+          return;
+        }
+
+        window.adsbygoogle = window.adsbygoogle || [];
+
+        slots.forEach(function (slot) {
+          if (slot.dataset.adLoaded === "true") {
+            return;
+          }
+
+          try {
+            window.adsbygoogle.push({});
+            slot.dataset.adLoaded = "true";
+          } catch (error) {
+            console.warn("Adsense slot error", error);
+          }
+        });
+      });
+    }
+  </script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- inject an AdSense slot into the Material right sidebar for the home page and Nano Banana gallery so the ad stays out of the main content
- re-run AdSense initialization on instant navigation events and add responsive styling for the sidebar slot
- register the new stylesheet and rely on the template-driven ad placement instead of inline markup in the Markdown files

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d56111b7148333a95e72f09625e933