### PR TITLE
Expand Sora 2 prompt catalogue

### DIFF
--- a/docs/text-to-video/awesome-sora2.en.md
+++ b/docs/text-to-video/awesome-sora2.en.md
@@ -1,0 +1,1314 @@
+---
+title: Sora 2 Text-to-Video Prompt Collection
+tags:
+  - TextToVideo
+  - Sora2
+---
+
+> Curated from [zhangchenchen/awesome_sora2_prompt](https://github.com/zhangchenchen/awesome_sora2_prompt) and [AI-Tool-List/Sora2-Prompt](https://github.com/AI-Tool-List/Sora2-Prompt). This page consolidates every prompt from both repositories into a single English reference.
+
+## 🎬 Overview
+
+This catalog aggregates official showcases, viral community experiments, cinematic landscapes, and curated galleries from Sora 2 prompt collections. Each entry retains the original English phrasing to ensure copy-ready accuracy.
+
+## Example 1 - Tokyo Walk
+
+**Prompt:**
+
+```text
+A stylish woman walks down a Tokyo street filled with warm glowing neon and animated city signage. She wears a black leather jacket, a long red dress, and black boots, and carries a black purse. She wears sunglasses and red lipstick. She walks confidently and casually. The street is damp and reflective, creating a mirror effect of the colorful lights. Many pedestrians walk about.
+```
+
+**Sources:** repo1/official-prompts.md, repo2/README.md#21
+
+## Example 2 - Wooly Mammoths
+
+**Prompt:**
+
+```text
+Several giant wooly mammoths approach treading through a snowy meadow, their long wooly fur lightly blows in the wind as they walk, snow covered trees and dramatic snow capped mountains in the distance, mid afternoon light with wispy clouds and a sun high in the distance creates a warm glow, the low camera view is stunning capturing the large furry mammal with beautiful photography, depth of field.
+```
+
+**Sources:** repo1/official-prompts.md, repo2/README.md#22
+
+## Example 3 - Mitten Astronaut
+
+**Prompt:**
+
+```text
+A movie trailer featuring the adventures of the 30 year old space man wearing a red wool knitted motorcycle helmet, blue sky, salt desert, cinematic style, shot on 35mm film, vivid colors.
+```
+
+**Sources:** repo1/official-prompts.md, repo2/README.md#25
+
+## Example 4 - Papercraft Coral Reef
+
+**Prompt:**
+
+```text
+A gorgeously rendered papercraft world of a coral reef, rife with colorful fish and sea creatures.
+```
+
+**Sources:** repo1/official-prompts.md, repo2/README.md#29
+
+## Example 5 - Big Sur Coastline
+
+**Prompt:**
+
+```text
+Drone view of waves crashing against the rugged cliffs along Big Sur's garay point beach. The crashing blue waters create white-tipped waves, while the golden light of the setting sun illuminates the rocky shore. A small island with a lighthouse sits in the distance, and green shrubbery covers the cliff's edge. The steep drop from the road down to the beach is a dramatic feat, with the cliff's edges jutting out over the sea. This is a view that captures the raw beauty of the coast and the rugged landscape of the Pacific Coast Highway.
+```
+
+**Sources:** repo1/official-prompts.md
+
+## Example 6 - Monster with Melting Candle
+
+**Prompt:**
+
+```text
+Animated scene features a close-up of a short fluffy monster kneeling beside a melting red candle. The art style is 3D and realistic, with a focus on lighting and texture. The mood of the painting is one of wonder and curiosity, as the monster gazes at the flame with wide eyes and open mouth. Its pose and expression convey a sense of innocence and playfulness, as if it is exploring the world around it for the first time. The use of warm colors and dramatic lighting further enhances the cozy atmosphere of the image.
+```
+
+**Sources:** repo1/official-prompts.md, repo2/README.md#28
+
+## Example 7 - Dragon over Glacier
+
+**Prompt:**
+
+```text
+Primary Target & Visuals:
+a dragon slicing past serrated ice spires jutting from a glacier, trailing embers that flare in its wake like fireflies, wings spread wide casting shadows on the sunlit ice below, arcing low over a deep fjord, the gap between its belly and the water barely a wingspan, steep walls looming on either side
+
+Format & Appearance:
+4K resolution, large-format digital sensor emulation, aspherical 50mm lens, fine grain simulation
+
+Camera & Filter:
+nose-mounted gimbal-stabilized aerial platform, tracking shot POV, 1/8 Black Pro-Mist filter for a gentle halation on highlights
+
+Grading & Palette:
+neutral to cool-temperature color palette (glacial blues, slate grays, pale mist whites), warm accents only on embers and reflected sunlight
+
+Lighting & Atmosphere:
+indirect natural light from late-afternoon sun angled low, subtle god-rays breaking through mist layers, soft atmospheric perspective fading distant peaks
+```
+
+**Sources:** repo1/official-prompts.md
+
+## Example 8 - Mountaineers Calling Out
+
+**Prompt:**
+
+```text
+Two mountain climbing explorers in red parkas stumble through fresh snow drifts in sequence, each calling out loudly into the white expanse as they climb toward a ridge
+```
+
+**Sources:** repo1/official-prompts.md
+
+## Example 9 - Volleyball Group Activity
+
+**Prompt:**
+
+```text
+a group of people playing volleyball
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 10 - Luxury Mercedes Ad
+
+**Prompt:**
+
+```text
+create a luxury ad for a black Mercedes Class G
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 11 - Soraception - Interface Simulation
+
+**Prompt:**
+
+```text
+open Sora, type a prompt in, and generate video!
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 12 - Live Stream Overlay Simulation
+
+**Prompt:**
+
+```text
+A live stream overlay with the streamer's webcam in the corner, showing a screen recording of him typing a prompt into Sora, generating a video and reacting as the result plays
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 13 - Full Video with Cameo Avatar
+
+**Prompt:**
+
+```text
+Testing out Sora 2... make an entire video using only prompts and have my cameo avatar say what I tell it to.
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 14 - Historical Rap Musical
+
+**Prompt:**
+
+```text
+star in a musical using American Revolution style. Topic of rap is 'The Innovator's Dilemma'
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 15 - CEO Rapper Parody
+
+**Prompt:**
+
+```text
+@sama is dressed like a rapper in the 2000s, he is talking about ain't nobody can come after him now that sora's free he gonna bankrupt all the other video companies, he's like what happened to that boy brrr
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 16 - Werewolf Transformation
+
+**Prompt:**
+
+```text
+Photorealistic Hipster, funny looking Man lays next to a camp fire staring up at the sky, it's a full moon, he looks at his hand it gets longer and grows hair, turning into the hand of a werewolf. His shoes break as his feet turn into giant werewolf feet, his nose gets longer, as he screams, his eyes turn and he if now finally a full werewolf, cinematic.
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 17 - Love Island Reality Parody
+
+**Prompt:**
+
+```text
+Love Island reveal scene. A young woman sits on a plush villa sofa during a tense "Movie Night" scene. She watches a large TV screen showing grainy CCTV-style footage: Real-life Ronald McDonald, dashing into a room with real-life Wendy. The audience and woman are shocked
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 18 - South Park Episode
+
+**Prompt:**
+
+```text
+the gang discovers Waymo
+```
+
+**Sources:** repo1/sora2-viral-prompts.md
+
+## Example 19 - Big Sur Coastline
+
+**Prompt:**
+
+```text
+Drone view of waves crashing against the rugged cliffs along Big Sur's garay point
+beach. The crashing blue waters create white-tipped waves, while the golden light
+of the setting sun illuminates the rocky shore. A small island with a lighthouse
+sits in the distance, and green shrubbery covers the cliff's edge. The steep drop
+from the road down to the beach is a dramatic feat, with the cliff's edges jutting
+out over the sea. This is a view that captures the raw beauty of the coast and the
+rugged landscape of the Pacific Coast Highway.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 20 - Ocean Storm
+
+**Prompt:**
+
+```text
+Cinematic footage of massive waves during a storm in the North Atlantic. Dark, turbulent
+waters rise into 30-foot swells, white foam and spray flying off the crests. Low,
+ominous clouds race overhead. Camera mounted on ship bow, rising and falling with the
+swells, creating visceral sense of power and danger. Shot on weatherproof cinema camera,
+high shutter speed captures water droplets frozen in mid-air. Dramatic, documentary-style
+cinematography emphasizing nature's raw power.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 21 - Snowy Mountain Range
+
+**Prompt:**
+
+```text
+Aerial drone shot soaring over a pristine mountain range at dawn. Fresh snow covers
+jagged peaks that catch the first pink and orange light of sunrise. Camera glides
+smoothly between peaks, revealing valleys filled with morning mist below. A frozen
+alpine lake reflects the colorful sky like a mirror. Pine trees at lower elevations
+are frosted with snow. Thin clouds drift between peaks. Cinematic, IMAX-quality
+landscape cinematography, shot on large format digital camera with exceptional clarity.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 22 - Autumn Forest Path
+
+**Prompt:**
+
+```text
+Steadicam shot gliding down a winding forest path in peak autumn. Trees ablaze with
+red, orange, and yellow foliage create a natural tunnel overhead. Fallen leaves carpet
+the ground in thick layers, some lifted by a gentle breeze swirling around the camera.
+Shafts of warm afternoon sunlight pierce through gaps in the canopy, illuminating
+floating leaves and creating volumetric light beams. Camera moves forward at walking
+pace, smooth and steady, inviting viewer to take a peaceful journey. Shot on 35mm film
+with rich, saturated fall colors.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 23 - Tokyo Night Streets
+
+**Prompt:**
+
+```text
+A stylish woman walks down a Tokyo street filled with warm glowing neon and animated
+city signage. She wears a black leather jacket, a long red dress, and black boots, and
+carries a black purse. She wears sunglasses and red lipstick. She walks confidently and
+casually. The street is damp and reflective, creating a mirror effect of the colorful
+lights. Many pedestrians walk about.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 24 - New York City Rush Hour
+
+**Prompt:**
+
+```text
+Time-lapse of New York City intersection during evening rush hour. Camera locked in
+high position looking down at busy crosswalk. Yellow taxis, pedestrians, cyclists all
+flow through frame in accelerated motion. Traffic lights cycle from red to green.
+Street lights turn on as sky transitions from blue hour to night. Long exposure effect
+creates light trails from vehicles. Urban energy and rhythm of the city compressed into
+dynamic time-lapse. Sharp focus throughout, deep depth of field showing entire scene.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 25 - Vineyard Landscape
+
+**Prompt:**
+
+```text
+Breathtaking drone shot rising over Tuscan vineyard at golden hour. Camera starts low
+between rows of grapevines, their leaves deep green and grapes hanging full. Slowly
+ascends while rotating, revealing geometric patterns of planted rows stretching to
+horizon. Medieval stone farmhouse and cypress trees come into view. Rolling hills in
+background catch warm sunset light. Shadows lengthen across the landscape. Smooth,
+cinematic drone operation with slow, majestic movement. Colors rich and saturated,
+emphasizing Mediterranean warmth.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 26 - Canyon Flight
+
+**Prompt:**
+
+```text
+FPV drone racing through narrow slot canyon in American Southwest. Camera flies at
+high speed between towering red rock walls, banking and twisting to navigate tight
+passages. Shafts of sunlight pierce down from the narrow opening above. Smooth rock
+walls blur past with incredible speed. Camera occasionally looks up showing thin strip
+of blue sky between walls. Adrenaline-pumping, dynamic flight cinematography. High
+frame rate captures crisp motion. Colors vibrant - deep red rocks, bright blue sky.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 27 - Thunderstorm Rolling In
+
+**Prompt:**
+
+```text
+Wide cinematic shot of a massive thunderstorm approaching across flat Kansas prairie.
+Dark, menacing wall of clouds advances toward camera with visible rain curtain beneath.
+Lightning flashes illuminate the storm's interior with brief, intense bursts. Wind whips
+through tall prairie grass in foreground, creating waves of motion. Last rays of sunlight
+break through at horizon, creating dramatic contrast between dark storm and golden light.
+Time slightly accelerated to show storm's progression. Shot on cinema camera with ND
+filters, high contrast, documentary weather cinematography.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 28 - Morning Fog Valley
+
+**Prompt:**
+
+```text
+Serene aerial shot of river valley filled with morning fog. Camera high above showing
+thick, white fog layer blanketing the valley floor like a cottony sea. Mountain peaks
+and hilltops poke through the fog layer like islands. Early morning sun creates soft,
+diffused light, edges of fog glowing golden. River barely visible as dark ribbon through
+the white. Complete stillness and tranquility. Slow, gentle camera movement floating
+peacefully above the scene. Meditative, ethereal quality. Colors muted and soft -
+whites, pale golds, soft blues.
+```
+
+**Sources:** repo1/hyperrealism-landscapes.md
+
+## Example 29 - Figure Skater Performs A Triple Axle With A Cat On
+
+**Prompt:**
+
+```text
+figure skater performs a triple axle with a cat on her head
+```
+
+**Sources:** repo2/README.md#1
+
+## Example 30 - Anime Style Fireworks Festival With Vibrant Colors
+
+**Prompt:**
+
+```text
+Anime style fireworks festival with vibrant colors
+```
+
+**Sources:** repo2/README.md#7
+
+## Example 31 - A Dog In Ghibli Animation Style Exploring A Magical Forest
+
+**Prompt:**
+
+```text
+A dog in Ghibli animation style exploring a magical forest
+```
+
+**Sources:** repo2/README.md#8
+
+## Example 32 - A Claymation Conductor Conducts A Claymation Orchestra
+
+**Prompt:**
+
+```text
+A claymation conductor conducts a claymation orchestra
+```
+
+**Sources:** repo2/README.md#11
+
+## Example 33 - Anime Character Awakening With Dramatic Lighting And Effects
+
+**Prompt:**
+
+```text
+Anime character awakening with dramatic lighting and effects
+```
+
+**Sources:** repo2/README.md#12
+
+## Example 34 - A Guy Does A Backflip
+
+**Prompt:**
+
+```text
+a guy does a backflip
+```
+
+**Sources:** repo2/README.md#2
+
+## Example 35 - Vikings Go To War — North Sea Launch (10.0S, Winter
+
+**Prompt:**
+
+```text
+Vikings Go To War — North Sea Launch (10.0s, Winter cool daylight / early medieval). Clinker-built longships push off from a frozen shore
+```
+
+**Sources:** repo2/README.md#3
+
+## Example 36 - Two Mountain Explorers In Bright Technical Shells, Ice Crusted Faces
+
+**Prompt:**
+
+```text
+Two mountain explorers in bright technical shells, ice crusted faces, eyes narrowed with urgency shout in the snow, one at a time
+```
+
+**Sources:** repo2/README.md#4
+
+## Example 37 - Academic Setting With Students In A Prestigious University
+
+**Prompt:**
+
+```text
+Academic setting with students in a prestigious university
+```
+
+**Sources:** repo2/README.md#13
+
+## Example 38 - Bigfoot Is Really Kind To Him, A Little Too Kind
+
+**Prompt:**
+
+```text
+Bigfoot is really kind to him, a little too kind, like oddly kind. Bigfoot wants to hang out but he wants to hang too much
+```
+
+**Sources:** repo2/README.md#5
+
+## Example 39 - An Astronaut Golden Retriever Named 'Sora' Levitates Around An Intergalactic
+
+**Prompt:**
+
+```text
+An astronaut golden retriever named 'Sora' levitates around an intergalactic pup-themed space station
+```
+
+**Sources:** repo2/README.md#6
+
+## Example 40 - A Dragon Slicing Past Serrated Ice Spires, Wingtip Vortices Peeling
+
+**Prompt:**
+
+```text
+A dragon slicing past serrated ice spires, wingtip vortices peeling spindrift. The glacier's fractured sheet falls away to a cobalt fjord, with amber sun rim kissing frost on scales
+```
+
+**Sources:** repo2/README.md#9
+
+## Example 41 - A Dalmatian Performing Olympic Gymnastics Routines
+
+**Prompt:**
+
+```text
+A Dalmatian performing Olympic gymnastics routines
+```
+
+**Sources:** repo2/README.md#10
+
+## Example 42 - Person With Cameo In A Magical Fantasy Setting
+
+**Prompt:**
+
+```text
+Person with cameo in a magical fantasy setting
+```
+
+**Sources:** repo2/README.md#14
+
+## Example 43 - Real Person Cameo In An Action Scene
+
+**Prompt:**
+
+```text
+Real person cameo in an action scene
+```
+
+**Sources:** repo2/README.md#15
+
+## Example 44 - Person Exploring A Surreal Dreamlike Environment
+
+**Prompt:**
+
+```text
+Person exploring a surreal dreamlike environment
+```
+
+**Sources:** repo2/README.md#16
+
+## Example 45 - Person In A Vibrant Urban Cyberpunk Setting
+
+**Prompt:**
+
+```text
+Person in a vibrant urban cyberpunk setting
+```
+
+**Sources:** repo2/README.md#17
+
+## Example 46 - Adventure Scene In An Exotic Jungle Location
+
+**Prompt:**
+
+```text
+Adventure scene in an exotic jungle location
+```
+
+**Sources:** repo2/README.md#18
+
+## Example 47 - Warm And Inviting Winter Cabin Scene With Realistic Lighting And
+
+**Prompt:**
+
+```text
+Warm and inviting winter cabin scene with realistic lighting and atmosphere
+```
+
+**Sources:** repo2/README.md#19
+
+## Example 48 - Person In An Underwater Oceanic Environment
+
+**Prompt:**
+
+```text
+Person in an underwater oceanic environment
+```
+
+**Sources:** repo2/README.md#20
+
+## Example 49 - Extreme Close Up Of A 24 Year Old Woman'S Eye
+
+**Prompt:**
+
+```text
+Extreme close up of a 24 year old woman's eye blinking, standing in Marrakech during magic hour, cinematic film shot in 70mm, depth of field, vivid colors, cinematic.
+```
+
+**Sources:** repo2/README.md#23
+
+## Example 50 - A Beautiful, Snowy Tokyo City Is Bustling. The Camera Moves
+
+**Prompt:**
+
+```text
+A beautiful, snowy Tokyo city is bustling. The camera moves through the bustling city street, following several people enjoying the beautiful snowy weather and shopping at nearby stalls.
+```
+
+**Sources:** repo2/README.md#24
+
+## Example 51 - Beautiful, Snowy Tokyo City Is Bustling. The Camera Moves Through
+
+**Prompt:**
+
+```text
+Beautiful, snowy Tokyo city is bustling. The camera moves through the bustling city street, following several people enjoying the beautiful snowy weather and shopping at nearby stalls. Gorgeous sakura petals are flying through the wind along with snowflakes.
+```
+
+**Sources:** repo2/README.md#26
+
+## Example 52 - The Camera Directly Faces Colorful Buildings In Burano Italy. An
+
+**Prompt:**
+
+```text
+The camera directly faces colorful buildings in Burano Italy. An adorable dalmation looks through a window on a building on the ground floor. Many people are walking and cycling along the canal streets in front of the buildings.
+```
+
+**Sources:** repo2/README.md#27
+
+## Example 53 - The Story Of A Robot'S Life In A Cyberpunk Setting
+
+**Prompt:**
+
+```text
+The story of a robot's life in a cyberpunk setting.
+```
+
+**Sources:** repo2/README.md#30
+
+## Example 54 - A Chinese Lunar New Year Celebration Video With Chinese Dragon
+
+**Prompt:**
+
+```text
+A Chinese Lunar New Year celebration video with Chinese Dragon.
+```
+
+**Sources:** repo2/README.md#31
+
+## Example 55 - Tour Of An Art Gallery With Many Beautiful Works Of
+
+**Prompt:**
+
+```text
+Tour of an art gallery with many beautiful works of art in different styles.
+```
+
+**Sources:** repo2/README.md#32
+
+## Example 56 - A Close Up View Of A Glass Sphere That Has
+
+**Prompt:**
+
+```text
+A close up view of a glass sphere that has a zen garden within it. There is a small dwarf in the sphere who is raking the zen garden and creating patterns in the sand.
+```
+
+**Sources:** repo2/README.md#33
+
+## Example 57 - Aerial View Of Santorini During The Blue Hour, Showcasing The
+
+**Prompt:**
+
+```text
+Aerial view of Santorini during the blue hour, showcasing the stunning architecture of white Cycladic buildings with blue domes. The caldera views are breathtaking, and the lighting creates a beautiful, serene atmosphere.
+```
+
+**Sources:** repo2/README.md#34
+
+## Example 58 - A Petri Dish With A Bamboo Forest Growing Within It
+
+**Prompt:**
+
+```text
+A petri dish with a bamboo forest growing within it that has tiny red pandas running around.
+```
+
+**Sources:** repo2/README.md#35
+
+## Example 59 - The Camera Rotates Around A Large Stack Of Vintage Televisions
+
+**Prompt:**
+
+```text
+The camera rotates around a large stack of vintage televisions all showing different programs — 1950s sci-fi movies, horror movies, news, static, a 1970s sitcom, etc, set inside a large New York museum gallery.
+```
+
+**Sources:** repo2/README.md#36
+
+## Example 60 - 3D Animation Of A Small, Round, Fluffy Creature With Big
+
+**Prompt:**
+
+```text
+3D animation of a small, round, fluffy creature with big, expressive eyes explores a vibrant, enchanted forest. The creature, a whimsical blend of a rabbit and a squirrel, has soft blue fur and a bushy, striped tail. It hops along a sparkling stream, its eyes wide with wonder. The forest is alive with magical elements: flowers that glow and change colors, trees with leaves in shades of purple and silver, and small floating lights that resemble fireflies. The creature stops to interact playfully with a group of tiny, fairy-like beings dancing around a mushroom ring. The creature looks up in awe at a large, glowing tree that seems to be the heart of the forest.
+```
+
+**Sources:** repo2/README.md#37
+
+## Example 61 - A Cartoon Kangaroo Disco Dances
+
+**Prompt:**
+
+```text
+A cartoon kangaroo disco dances.
+```
+
+**Sources:** repo2/README.md#38
+
+## Example 62 - A Young Man At His 20S Is Sitting On A
+
+**Prompt:**
+
+```text
+A young man at his 20s is sitting on a piece of cloud in the sky, reading a book.
+```
+
+**Sources:** repo2/README.md#39
+
+## Example 63 - Historical Footage Of California During The Gold Rush
+
+**Prompt:**
+
+```text
+Historical footage of California during the gold rush.
+```
+
+**Sources:** repo2/README.md#40
+
+## Example 64 - A Close Up View Of A Papercraft Underwater Scene. A
+
+**Prompt:**
+
+```text
+A close up view of a papercraft underwater scene. A blue whale swims through the frame, with cardboard fish and sea creatures drifting alongside it.
+```
+
+**Sources:** repo2/README.md#41
+
+## Example 65 - Photorealistic Closeup Video Of Two Pirate Ships Battling Each Other
+
+**Prompt:**
+
+```text
+Photorealistic closeup video of two pirate ships battling each other as they sail inside a cup of coffee.
+```
+
+**Sources:** repo2/README.md#42
+
+## Example 66 - A Grandmother With Neatly Combed Grey Hair Stands Behind A
+
+**Prompt:**
+
+```text
+A grandmother with neatly combed grey hair stands behind a colorful birthday cake with numerous candles at a wood dining room table, expression is one of pure joy and happiness, with a happy glow in her eye. She leans forward and blows out the candles with a gentle puff, the cake has pink frosting and sprinkles and the candles cease to flicker, the grandmother wears a light blue blouse adorned with floral patterns, several happy friends and family sitting at the table can be seen celebrating, out of focus. The scene is beautifully captured, cinematic, showing a 3/4 view of the grandmother and the dining room. Warm color tones and soft lighting enhance the mood.
+```
+
+**Sources:** repo2/README.md#43
+
+## Example 67 - The Camera Follows Behind A White Vintage Suv With A
+
+**Prompt:**
+
+```text
+The camera follows behind a white vintage SUV with a black roof rack as it speeds up a steep dirt road surrounded by pine trees on a steep mountain slope, dust kicks up from its tires, the sunlight shines on the SUV as it speeds along the dirt road, casting a warm glow over the scene. The dirt road curves gently into the distance, with no other cars or vehicles in sight. The trees on either side of the road are redwoods, with patches of greenery scattered throughout. The car is seen from the rear following the curve with ease, making it seem as if it is on a rugged drive through the rugged terrain. The dirt road itself is surrounded by steep hills and mountains, with a clear blue sky above with wispy clouds.
+```
+
+**Sources:** repo2/README.md#44
+
+## Example 68 - Reflections In The Window Of A Train Traveling Through The
+
+**Prompt:**
+
+```text
+Reflections in the window of a train traveling through the Tokyo suburbs.
+```
+
+**Sources:** repo2/README.md#45
+
+## Example 69 - A Drone Camera Circles Around A Beautiful Historic Church Built
+
+**Prompt:**
+
+```text
+A drone camera circles around a beautiful historic church built on a rocky outcropping along the Amalfi Coast, the view showcases historic and magnificent architectural details and tiered pathways and patios, waves are seen crashing against the rocks below as the view overlooks the horizon of the coastal waters and hilly landscapes of the Amalfi Coast Italy, several distant people are seen walking and enjoying vistas on patios of the dramatic ocean views, the warm glow of the afternoon sun creates a magical and romantic feeling to the scene, the view is stunning captured with beautiful photography.
+```
+
+**Sources:** repo2/README.md#46
+
+## Example 70 - A Litter Of Golden Retriever Puppies Playing In The Snow
+
+**Prompt:**
+
+```text
+A litter of golden retriever puppies playing in the snow. Their heads pop out of the snow, covered in.
+```
+
+**Sources:** repo2/README.md#47
+
+## Example 71 - Step-Print Photography Of A Person Running, Cinematic Film Shot In
+
+**Prompt:**
+
+```text
+Step-print photography of a person running, cinematic film shot in 35mm.
+```
+
+**Sources:** repo2/README.md#48
+
+## Example 72 - A Bicycle Race On Ocean With Different Animals As Athletes
+
+**Prompt:**
+
+```text
+A bicycle race on ocean with different animals as athletes riding the bicycles with drone camera view.
+```
+
+**Sources:** repo2/README.md#49
+
+## Example 73 - Tiltshift Of A Construction Site Filled With Workers, Equipment, And
+
+**Prompt:**
+
+```text
+Tiltshift of a construction site filled with workers, equipment, and heavy machinery.
+```
+
+**Sources:** repo2/README.md#50
+
+## Example 74 - A Flock Of Paper Airplanes Flutters Through A Dense Jungle
+
+**Prompt:**
+
+```text
+A flock of paper airplanes flutters through a dense jungle, weaving around trees as if they were migrating birds.
+```
+
+**Sources:** repo2/README.md#51
+
+## Example 75 - A Cat Waking Up Its Sleeping Owner Demanding Breakfast. The
+
+**Prompt:**
+
+```text
+A cat waking up its sleeping owner demanding breakfast. The owner tries to ignore the cat, but the cat tries new tactics and finally the owner pulls out a secret stash of treats from under the pillow to hold the cat off a little longer.
+```
+
+**Sources:** repo2/README.md#52
+
+## Example 76 - Borneo Wildlife On The Kinabatangan River
+
+**Prompt:**
+
+```text
+Borneo wildlife on the Kinabatangan River.
+```
+
+**Sources:** repo2/README.md#53
+
+## Example 77 - A Chinese Man Stands In Chinese Mountains And Makes Tai
+
+**Prompt:**
+
+```text
+A Chinese man stands in Chinese mountains and makes Tai Chi moves, facial closeup.
+```
+
+**Sources:** repo2/README.md#54
+
+## Example 78 - A Steam Train Passes Through An Ornate Marble And Brass
+
+**Prompt:**
+
+```text
+A steam train passes through an ornate marble and brass station, people are waiting at the platforms as the train passes by, sparks flying from the train as it moves. Golden hour light, soft shadows, vintage color grading.
+```
+
+**Sources:** repo2/README.md#55
+
+## Example 79 - An Extreme Close-Up Of An Gray-Haired Man With A Beard
+
+**Prompt:**
+
+```text
+An extreme close-up of an gray-haired man with a beard in his 60s, he is deep in thought pondering the history of the universe as he sits at a cafe in Paris, his eyes focus on people offscreen as they walk as he sits mostly motionless, he is dressed in a wool coat suit coat with a button-down shirt, he wears a brown beret and glasses and has a very professorial appearance, and the end he offers a subtle closed-mouth smile as if he found the answer to the mystery of life, the lighting is very cinematic with the golden light and the Parisian streets and city in the background, depth of field, cinematic 35mm film.
+```
+
+**Sources:** repo2/README.md#56
+
+## Example 80 - A Large Orange Octopus Is Seen Resting On The Bottom
+
+**Prompt:**
+
+```text
+A large orange octopus is seen resting on the bottom of the ocean floor, blending in with the sandy and rocky terrain. Its tentacles are spread out around its body, and its eyes are closed. The octopus is unaware of a king crab that is crawling towards it from behind a rock, its claws raised and ready to attack. The crab is brown and spiny, with long legs and antennae. The scene is captured from a wide angle, showing the vastness and depth of the ocean. The water is clear and blue, with rays of sunlight filtering through. The shot is sharp and crisp, with a high dynamic range. The octopus and the crab are in focus, while the background is slightly blurred, creating a depth of field effect.
+```
+
+**Sources:** repo2/README.md#57
+
+## Example 81 - A Vibrant Scene Of A Musician Performing On Stage, Surrounded
+
+**Prompt:**
+
+```text
+A vibrant scene of a musician performing on stage, surrounded by a mesmerized audience. The stage is bathed in colorful spotlights and the musician plays an electric guitar with passion and energy. The crowd is cheering and dancing, creating an electrifying atmosphere. The camera pans around the stage, capturing the energy and excitement of the performance from different angles.
+```
+
+**Sources:** repo2/README.md#58
+
+## Example 82 - A Medium-Sized Mixed-Breed Dog, With A Mix Of Brown And
+
+**Prompt:**
+
+```text
+A medium-sized mixed-breed dog, with a mix of brown and black fur, is seen running through a large, open field. The dog is captured in mid-stride, with all four legs off the ground, showcasing its speed and agility. The field is filled with tall green grass that sways gently in the wind, and wildflowers dot the landscape, adding splashes of color. The background features a line of trees, their leaves rustling softly, and a partly cloudy sky above. The sunlight casts a warm, golden glow over the scene, highlighting the dog's fur and creating dynamic shadows. The shot is taken with a steady cam, keeping the dog in focus while the background blurs slightly, emphasizing the motion and energy of the moment.
+```
+
+**Sources:** repo2/README.md#59
+
+## Example 83 - A Dystopian Future Cityscape At Night, Neon Lights Reflecting Off
+
+**Prompt:**
+
+```text
+A dystopian future cityscape at night, neon lights reflecting off wet streets, towering skyscrapers piercing through thick smog. A lone figure in a long coat walks through the rain-soaked streets, the camera follows from behind, capturing the gritty, atmospheric environment with deep shadows and vibrant neon colors. Cinematic, shot in 4K, inspired by Blade Runner.
+```
+
+**Sources:** repo2/README.md#60
+
+## Example 84 - An Underwater Expedition Through A Vibrant Coral Reef, Schools Of
+
+**Prompt:**
+
+```text
+An underwater expedition through a vibrant coral reef, schools of tropical fish swimming gracefully. Sunlight filters through the water, creating dancing patterns of light. A sea turtle glides majestically through the frame. Shot with underwater cinematography techniques, crystal clear water, rich colors.
+```
+
+**Sources:** repo2/README.md#61
+
+## Example 85 - A Time-Lapse Of A Bustling City Intersection At Rush Hour
+
+**Prompt:**
+
+```text
+A time-lapse of a bustling city intersection at rush hour, people crossing in all directions, traffic lights changing, vehicles flowing. The camera is positioned high above, capturing the organized chaos from a bird's eye view. Golden hour lighting, long shadows, urban energy.
+```
+
+**Sources:** repo2/README.md#62
+
+## Example 86 - A Majestic Eagle Soaring Through A Mountain Canyon At Sunrise
+
+**Prompt:**
+
+```text
+A majestic eagle soaring through a mountain canyon at sunrise, wings spread wide catching the golden light. The camera flies alongside the eagle, matching its graceful movements. Snow-capped peaks in the background, morning mist in the valleys below. Cinematic wildlife photography, 4K, inspiring and epic.
+```
+
+**Sources:** repo2/README.md#63
+
+## Example 87 - A Professional Chef Preparing Sushi In A Traditional Japanese Restaurant
+
+**Prompt:**
+
+```text
+A professional chef preparing sushi in a traditional Japanese restaurant, hands moving with precision and grace. Close-up shots of fresh fish being sliced, rice being shaped, ingredients being carefully arranged. Soft natural lighting, minimalist aesthetic, focus on craftsmanship and detail.
+```
+
+**Sources:** repo2/README.md#64
+
+## Example 88 - A Peaceful Meditation Scene In A Misty Bamboo Forest At
+
+**Prompt:**
+
+```text
+A peaceful meditation scene in a misty bamboo forest at dawn. A monk in orange robes sits in lotus position on a stone platform. Rays of sunlight pierce through the fog, creating an ethereal atmosphere. Gentle breeze moves the bamboo, birds chirping softly. Serene, spiritual, contemplative mood.
+```
+
+**Sources:** repo2/README.md#65
+
+## Example 89 - A High-Speed Car Chase Through Narrow European Streets, Camera Mounted
+
+**Prompt:**
+
+```text
+A high-speed car chase through narrow European streets, camera mounted on the pursuing vehicle. Sharp turns, close calls with pedestrians, tires screeching. The architecture blurs past, historic buildings and cobblestone streets. Adrenaline-pumping action sequence, dynamic camera work, intense energy.
+```
+
+**Sources:** repo2/README.md#66
+
+## Example 90 - A Magical Library With Floating Books, Glowing Manuscripts, And Spiral
+
+**Prompt:**
+
+```text
+A magical library with floating books, glowing manuscripts, and spiral staircases leading to impossible heights. A young wizard in robes walks through, trailing sparkles of magic. Books flutter open, revealing illuminated pages. Fantasy aesthetic, warm golden lighting, sense of wonder and mystery.
+```
+
+**Sources:** repo2/README.md#67
+
+## Example 91 - A Microscopic Journey Through The Human Bloodstream, Red Blood Cells
+
+**Prompt:**
+
+```text
+A microscopic journey through the human bloodstream, red blood cells flowing through veins, white blood cells attacking bacteria. The camera travels through arteries and capillaries, showing the inner workings of the circulatory system. Educational, scientifically accurate, beautifully rendered in 3D.
+```
+
+**Sources:** repo2/README.md#68
+
+## Example 92 - A Jazz Quartet Performing In A Dimly Lit, Smoke-Filled Club
+
+**Prompt:**
+
+```text
+A jazz quartet performing in a dimly lit, smoke-filled club. Saxophone player takes a solo, fingers dancing on the keys. Drummer keeps the rhythm, bass player nods along. Audience members sway in the background. Moody lighting, film noir atmosphere, vintage 1950s aesthetic.
+```
+
+**Sources:** repo2/README.md#69
+
+## Example 93 - A Blacksmith'S Forge In Medieval Times, Hammer Striking Red-Hot Iron
+
+**Prompt:**
+
+```text
+A blacksmith's forge in medieval times, hammer striking red-hot iron on an anvil, sparks flying. The blacksmith, a burly man with soot-covered face, shapes a sword with powerful, rhythmic strikes. Fire glows in the background, casting dramatic shadows. Historical authenticity, harsh lighting, gritty realism.
+```
+
+**Sources:** repo2/README.md#70
+
+## Example 94 - A Ballet Dancer Performing Swan Lake On A Grand Theater
+
+**Prompt:**
+
+```text
+A ballet dancer performing Swan Lake on a grand theater stage, spotlight following her graceful movements. She leaps and spins with perfect technique, costume flowing elegantly. Orchestra pit visible below, ornate theater architecture in the background. Classical, refined, capturing the beauty of dance.
+```
+
+**Sources:** repo2/README.md#71
+
+## Example 95 - A Science Fiction Scene Of A Space Station Orbiting A
+
+**Prompt:**
+
+```text
+A science fiction scene of a space station orbiting a distant planet, astronauts performing a spacewalk to repair solar panels. Earth-like planet with rings visible in the background, stars scattered across space. Realistic zero-gravity movements, futuristic technology, awe-inspiring cosmic vista.
+```
+
+**Sources:** repo2/README.md#72
+
+## Example 96 - A Monsoon Rain In An Indian Village, Water Cascading From
+
+**Prompt:**
+
+```text
+A monsoon rain in an Indian village, water cascading from rooftops, children dancing and playing in the downpour. Colorful saris hang from windows, peacocks strut in the rain. The camera captures the joy and relief after a long dry season. Vibrant colors, cultural authenticity, celebration of nature.
+```
+
+**Sources:** repo2/README.md#73
+
+## Example 97 - A Pastry Chef Decorating An Elaborate Wedding Cake, Piping Intricate
+
+**Prompt:**
+
+```text
+A pastry chef decorating an elaborate wedding cake, piping intricate floral designs with buttercream. Extreme close-up of skilled hands working with precision. Multiple tiers, delicate sugar flowers, elegant patterns. Soft studio lighting, pristine white aesthetic, showcasing culinary artistry.
+```
+
+**Sources:** repo2/README.md#74
+
+## Example 98 - A Volcanic Eruption At Night, Lava Fountaining Into The Dark
+
+**Prompt:**
+
+```text
+A volcanic eruption at night, lava fountaining into the dark sky, rivers of molten rock flowing down the mountainside. Lightning crackling in the ash cloud above. The camera captures the raw power of nature, the intense heat creating a red-orange glow. Epic, dramatic, showcasing nature's fury.
+```
+
+**Sources:** repo2/README.md#75
+
+## Example 99 - A Hummingbird Feeding From A Vibrant Red Hibiscus Flower, Wings
+
+**Prompt:**
+
+```text
+A hummingbird feeding from a vibrant red hibiscus flower, wings beating so fast they're a blur. Extreme slow-motion captures the intricate details: iridescent feathers, long curved beak, droplets of nectar. Shallow depth of field, tropical garden background, macro wildlife photography.
+```
+
+**Sources:** repo2/README.md#76
+
+## Example 100 - A Victorian-Era Detective In A Foggy London Street, Gas Lamps
+
+**Prompt:**
+
+```text
+A Victorian-era detective in a foggy London street, gas lamps casting eerie glows. The detective in a long coat and top hat examines clues with a magnifying glass. Horse-drawn carriages pass in the background, cobblestone streets wet from rain. Mysterious, atmospheric, Sherlock Holmes aesthetic.
+```
+
+**Sources:** repo2/README.md#77
+
+## Example 101 - A Parkour Athlete Navigating An Urban Jungle, Leaping Between Rooftops
+
+**Prompt:**
+
+```text
+A parkour athlete navigating an urban jungle, leaping between rooftops, vaulting over obstacles, scaling walls. The camera follows with smooth gimbal movements, capturing the fluid athleticism and daring jumps. Sunset lighting, cityscape background, adrenaline and freedom.
+```
+
+**Sources:** repo2/README.md#78
+
+## Example 102 - A Glassblower Shaping Molten Glass, Gathering Glowing Orange Glass On
+
+**Prompt:**
+
+```text
+A glassblower shaping molten glass, gathering glowing orange glass on a blowpipe, shaping it with tools and breath. The glass transforms from shapeless blob to elegant vase. The furnace glows intensely in the background. Craftsmanship, artistic process, mesmerizing transformation.
+```
+
+**Sources:** repo2/README.md#79
+
+## Example 103 - A Bioluminescent Bay At Night, Millions Of Tiny Organisms Glowing
+
+**Prompt:**
+
+```text
+A bioluminescent bay at night, millions of tiny organisms glowing blue with every movement in the water. A kayak glides through, leaving a trail of ethereal light. Stars reflected on the water's surface. Magical, surreal, capturing one of nature's most stunning phenomena.
+```
+
+**Sources:** repo2/README.md#80
+
+## Example 104 - An Ice Cave In Iceland, Blue Glacial Ice Formations, Light
+
+**Prompt:**
+
+```text
+An ice cave in Iceland, blue glacial ice formations, light filtering through translucent walls. A lone explorer with a headlamp examines the intricate ice structures. The cave appears otherworldly, with icicles and frozen patterns. Cold color palette, natural wonder, sense of exploration.
+```
+
+**Sources:** repo2/README.md#81
+
+## Example 105 - A Traditional Tea Ceremony In Japan, Hands Carefully Pouring Matcha
+
+**Prompt:**
+
+```text
+A traditional tea ceremony in Japan, hands carefully pouring matcha, whisking in a precise ritual. Steam rises from the bowl, tatami mats visible, minimalist room with shoji screens. Meditative, focusing on mindfulness and tradition. Soft natural lighting, peaceful atmosphere.
+```
+
+**Sources:** repo2/README.md#82
+
+## Example 106 - A Roller Coaster At An Amusement Park From A Front-Seat
+
+**Prompt:**
+
+```text
+A roller coaster at an amusement park from a front-seat POV, climbing the first hill then plunging down. Riders' hands raised, screaming in excitement. The track twists and loops, with quick cuts showing different perspectives. Thrilling, visceral, capturing the rush of the ride.
+```
+
+**Sources:** repo2/README.md#83
+
+## Example 107 - A Watchmaker Repairing An Antique Pocket Watch, Tiny Gears And
+
+**Prompt:**
+
+```text
+A watchmaker repairing an antique pocket watch, tiny gears and springs visible under a magnifying lamp. Delicate tools manipulate microscopic components. The craftsmanship and patience required for the intricate work is evident. Close-up, detailed, appreciation for precision engineering.
+```
+
+**Sources:** repo2/README.md#84
+
+## Example 108 - A Shepherd Leading A Flock Of Sheep Across Rolling Green
+
+**Prompt:**
+
+```text
+A shepherd leading a flock of sheep across rolling green hills at sunset, herding dog running alongside. Ancient stone walls divide the pastoral landscape. The shepherd's weathered face tells stories of a life connected to the land. Peaceful, timeless, rural lifestyle.
+```
+
+**Sources:** repo2/README.md#85
+
+## Example 109 - A Fashion Runway Show, Models Walking Confidently Down The Catwalk
+
+**Prompt:**
+
+```text
+A fashion runway show, models walking confidently down the catwalk in avant-garde designs. Photographers' flashes create bursts of light, audience members lean forward in their seats. The clothing is bold and artistic, pushing boundaries. High fashion, glamorous, artistic expression.
+```
+
+**Sources:** repo2/README.md#86
+
+## Example 110 - A Potter At A Wheel, Hands Shaping Wet Clay Into
+
+**Prompt:**
+
+```text
+A potter at a wheel, hands shaping wet clay into a vessel. The wheel spins steadily as the pot takes form, rising and expanding under skilled fingers. Clay splatter, water glistening, focused expression. The process is meditative and tactile. Artisan craft, earthy aesthetic.
+```
+
+**Sources:** repo2/README.md#87
+
+## Example 111 - A Northern Lights Display Over A Frozen Norwegian Fjord, Green
+
+**Prompt:**
+
+```text
+A Northern Lights display over a frozen Norwegian fjord, green and purple auroras dancing across the night sky. A small cabin with warm light glowing from windows sits by the shore. Snow-covered mountains reflected in still water. Breathtaking, magical, natural wonder.
+```
+
+**Sources:** repo2/README.md#88
+
+## Example 112 - A Sommelier In An Elegant Restaurant, Swirling Wine In A
+
+**Prompt:**
+
+```text
+A sommelier in an elegant restaurant, swirling wine in a glass, examining color and clarity. Close-up of wine being poured, legs flowing down the glass. The sommelier savors the aroma, then tastes thoughtfully. Sophisticated, refined, appreciation of wine culture.
+```
+
+**Sources:** repo2/README.md#89
+
+## Example 113 - A Street Artist Creating A Massive Chalk Drawing On Pavement
+
+**Prompt:**
+
+```text
+A street artist creating a massive chalk drawing on pavement, aerial view shows the incredible detail and scale. Passersby stop to watch and photograph. The artwork is a trompe-l'oeil creating illusion of 3D depth. Creative, impressive, temporary art.
+```
+
+**Sources:** repo2/README.md#90
+
+## Example 114 - A Butterfly Emerging From Its Chrysalis, Wings Slowly Unfurling And
+
+**Prompt:**
+
+```text
+A butterfly emerging from its chrysalis, wings slowly unfurling and drying. Time-lapse captures the transformation from cramped cocoon to fully formed butterfly. Dewdrops on leaves, morning light, delicate wings displaying vibrant patterns. Natural metamorphosis, rebirth, beauty of nature.
+```
+
+**Sources:** repo2/README.md#91
+
+## Example 115 - A Chocolate Maker Tempering Chocolate, Pouring Glossy Dark Chocolate Into
+
+**Prompt:**
+
+```text
+A chocolate maker tempering chocolate, pouring glossy dark chocolate into molds. Steam rises as hot chocolate meets cold marble. The finished products are perfect bonbons with shiny shells. The scene captures the precision and artistry of chocolate making. Indulgent, luxurious, culinary craft.
+```
+
+**Sources:** repo2/README.md#92
+
+## Example 116 - A Thunderstorm Rolling Over Kansas Wheat Fields, Dark Clouds Churning
+
+**Prompt:**
+
+```text
+A thunderstorm rolling over Kansas wheat fields, dark clouds churning, lightning bolts striking. Wind whips through golden wheat, creating waves across the landscape. A barn and windmill stand resilient. The power and drama of Midwest weather. Epic, dramatic, natural forces.
+```
+
+**Sources:** repo2/README.md#93
+
+## Example 117 - A Calligrapher Creating Chinese Characters With Brush And Ink, Each
+
+**Prompt:**
+
+```text
+A calligrapher creating Chinese characters with brush and ink, each stroke deliberate and flowing. Black ink on white rice paper, the characters taking shape with artistic flair. Focus on the brush tip, ink spreading into the paper fibers. Meditative, artistic, cultural tradition.
+```
+
+**Sources:** repo2/README.md#94
+
+## Example 118 - A Deep Sea Submersible Descending Into The Mariana Trench, Lights
+
+**Prompt:**
+
+```text
+A deep sea submersible descending into the Mariana Trench, lights illuminating bizarre deep-sea creatures. Bioluminescent jellyfish, translucent fish with oversized eyes, strange formations on the ocean floor. The darkness and pressure create an alien environment. Scientific exploration, mysterious, otherworldly.
+```
+
+**Sources:** repo2/README.md#95
+
+## Example 119 - A Moroccan Souk At Dusk, Vendors Selling Spices, Textiles, And
+
+**Prompt:**
+
+```text
+A Moroccan souk at dusk, vendors selling spices, textiles, and lanterns. Colorful fabrics hang overhead, filtering golden sunlight. Shoppers haggle and browse, the air filled with scents of cumin and mint tea. Bustling, exotic, sensory-rich cultural scene.
+```
+
+**Sources:** repo2/README.md#96
+
+## Example 120 - A Skateboarding Trick In Slow Motion, Athlete Performing A Kickflip
+
+**Prompt:**
+
+```text
+A skateboarding trick in slow motion, athlete performing a kickflip over a gap. Focus on the board rotating, shoes guiding the flip, concentration on the skater's face. Urban skate park setting, graffiti walls, friends cheering. Youth culture, skill, determination.
+```
+
+**Sources:** repo2/README.md#97
+
+## Example 121 - A Beehive In Cross-Section, Thousands Of Bees Working In Organized
+
+**Prompt:**
+
+```text
+A beehive in cross-section, thousands of bees working in organized chaos. The queen surrounded by attendants, workers building honeycomb, foragers returning with pollen. The intricate social structure of the colony is visible. Educational, fascinating, natural engineering.
+```
+
+**Sources:** repo2/README.md#98
+
+## Example 122 - A Flamenco Dancer In A Spotlight, Red Dress Swirling As
+
+**Prompt:**
+
+```text
+A flamenco dancer in a spotlight, red dress swirling as she stamps and spins. Guitarist strums passionately in the background, hands clapping rhythm. The dancer's expression is intense, embodying the emotion of the music. Spanish culture, passionate, dramatic performance.
+```
+
+**Sources:** repo2/README.md#99
+
+## Example 123 - A Hot Air Balloon Festival At Sunrise, Dozens Of Colorful
+
+**Prompt:**
+
+```text
+A hot air balloon festival at sunrise, dozens of colorful balloons inflating and lifting off. Aerial shots show the patchwork of balloons floating over countryside. Passengers wave from baskets, burners roar, creating pillars of flame. Joyful, colorful, celebration of flight.
+```
+
+**Sources:** repo2/README.md#100
+
+## 📚 Sources
+
+- [zhangchenchen/awesome_sora2_prompt](https://github.com/zhangchenchen/awesome_sora2_prompt)
+- [AI-Tool-List/Sora2-Prompt](https://github.com/AI-Tool-List/Sora2-Prompt)

--- a/docs/text-to-video/awesome-sora2.md
+++ b/docs/text-to-video/awesome-sora2.md
@@ -1,0 +1,2052 @@
+---
+title: Sora 2 文生视频提示词大全
+tags:
+  - TextToVideo
+  - Sora2
+---
+
+> 重排自 [zhangchenchen/awesome_sora2_prompt](https://github.com/zhangchenchen/awesome_sora2_prompt) 与 [AI-Tool-List/Sora2-Prompt](https://github.com/AI-Tool-List/Sora2-Prompt)，整合两个仓库中的全部提示词，提供中英文对照。
+
+## 🎬 简介
+
+本页完整收录两个仓库的所有 Sora / Sora 2 提示词。每条目均保留英文原文，补充中文翻译，方便复制与二次创作。
+
+## 例1-东京漫步 (Tokyo Walk)
+
+**英文提示词：**
+
+```text
+A stylish woman walks down a Tokyo street filled with warm glowing neon and animated city signage. She wears a black leather jacket, a long red dress, and black boots, and carries a black purse. She wears sunglasses and red lipstick. She walks confidently and casually. The street is damp and reflective, creating a mirror effect of the colorful lights. Many pedestrians walk about.
+```
+
+**中文翻译：**
+
+```text
+一位时尚女性走在东京街头，街道上充满了温暖的霓虹灯光和生动的城市广告牌。她穿着黑色皮夹克，红色长裙和黑色靴子，手提黑色手袋。她戴着太阳镜，涂着红色口红。她走路自信而随意。街道潮湿且有反光，形成色彩斑斓的灯光镜面效果。许多行人来来往往。
+```
+
+**来源：** repo1/official-prompts.md, repo2/README.md#21
+
+## 例2-毛象 (Wooly Mammoths)
+
+**英文提示词：**
+
+```text
+Several giant wooly mammoths approach treading through a snowy meadow, their long wooly fur lightly blows in the wind as they walk, snow covered trees and dramatic snow capped mountains in the distance, mid afternoon light with wispy clouds and a sun high in the distance creates a warm glow, the low camera view is stunning capturing the large furry mammal with beautiful photography, depth of field.
+```
+
+**中文翻译：**
+
+```text
+几只巨大的长毛象缓步穿过雪地草甸，它们长长的毛发在微风中轻轻飘动，远处是被雪覆盖的树木和壮丽的积雪山脉。午后时分，稀薄的云朵和高悬的太阳创造出温暖的光辉。从低角度拍摄的视角令人惊叹，完美捕捉到了这些巨大的毛茸茸动物，摄影效果极佳，景深出众。
+```
+
+**来源：** repo1/official-prompts.md, repo2/README.md#22
+
+## 例3-手套宇航员 (Mitten Astronaut)
+
+**英文提示词：**
+
+```text
+A movie trailer featuring the adventures of the 30 year old space man wearing a red wool knitted motorcycle helmet, blue sky, salt desert, cinematic style, shot on 35mm film, vivid colors.
+```
+
+**中文翻译：**
+
+```text
+一部电影预告片，讲述一位30岁的宇航员戴着红色羊毛针织摩托车头盔的冒险故事，蓝天、盐地沙漠，电影风格，采用35毫米胶片拍摄，色彩鲜艳。
+```
+
+**来源：** repo1/official-prompts.md, repo2/README.md#25
+
+## 例4-纸工珊瑚礁 (Papercraft Coral Reef)
+
+**英文提示词：**
+
+```text
+A gorgeously rendered papercraft world of a coral reef, rife with colorful fish and sea creatures.
+```
+
+**中文翻译：**
+
+```text
+一个精美呈现的纸艺珊瑚礁世界，充满了色彩斑斓的鱼类和海洋生物。
+```
+
+**来源：** repo1/official-prompts.md, repo2/README.md#29
+
+## 例5-大瑟尔海岸线 (Big Sur Coastline)
+
+**英文提示词：**
+
+```text
+Drone view of waves crashing against the rugged cliffs along Big Sur's garay point beach. The crashing blue waters create white-tipped waves, while the golden light of the setting sun illuminates the rocky shore. A small island with a lighthouse sits in the distance, and green shrubbery covers the cliff's edge. The steep drop from the road down to the beach is a dramatic feat, with the cliff's edges jutting out over the sea. This is a view that captures the raw beauty of the coast and the rugged landscape of the Pacific Coast Highway.
+```
+
+**中文翻译：**
+
+```text
+无人机视角拍摄的海浪拍打大苏尔加雷角海滩崎岖悬崖的景象。翻滚的蓝色海水冲击出白色浪尖，而落日的金色光辉照亮了岩石海岸。远处有一个小岛，上面建有灯塔，悬崖边缘覆盖着绿色灌木。从道路到海滩的陡坡形成了戏剧性的景观，悬崖边缘伸向大海。这一景象展现了海岸的原始之美以及太平洋海岸公路崎岖的地貌。
+```
+
+**来源：** repo1/official-prompts.md
+
+## 例6-融化蜡烛的怪物 (Monster with Melting Candle)
+
+**英文提示词：**
+
+```text
+Animated scene features a close-up of a short fluffy monster kneeling beside a melting red candle. The art style is 3D and realistic, with a focus on lighting and texture. The mood of the painting is one of wonder and curiosity, as the monster gazes at the flame with wide eyes and open mouth. Its pose and expression convey a sense of innocence and playfulness, as if it is exploring the world around it for the first time. The use of warm colors and dramatic lighting further enhances the cozy atmosphere of the image.
+```
+
+**中文翻译：**
+
+```text
+动画场景展示了一只短小毛茸茸的怪物跪在一根正在融化的红色蜡烛旁的特写画面。艺术风格为3D写实，强调光影和质感。画面的氛围充满了奇妙与好奇，怪物睁大眼睛、张开嘴巴凝视着火焰。它的姿势和表情传达出天真和顽皮的感觉，仿佛第一次在探索周围的世界。使用温暖的色彩和戏剧性的光影进一步增强了画面的温馨气氛。
+```
+
+**来源：** repo1/official-prompts.md, repo2/README.md#28
+
+## 例7-冰川上的龙 (Dragon over Glacier)
+
+**英文提示词：**
+
+```text
+Primary Target & Visuals:
+a dragon slicing past serrated ice spires jutting from a glacier, trailing embers that flare in its wake like fireflies, wings spread wide casting shadows on the sunlit ice below, arcing low over a deep fjord, the gap between its belly and the water barely a wingspan, steep walls looming on either side
+
+Format & Appearance:
+4K resolution, large-format digital sensor emulation, aspherical 50mm lens, fine grain simulation
+
+Camera & Filter:
+nose-mounted gimbal-stabilized aerial platform, tracking shot POV, 1/8 Black Pro-Mist filter for a gentle halation on highlights
+
+Grading & Palette:
+neutral to cool-temperature color palette (glacial blues, slate grays, pale mist whites), warm accents only on embers and reflected sunlight
+
+Lighting & Atmosphere:
+indirect natural light from late-afternoon sun angled low, subtle god-rays breaking through mist layers, soft atmospheric perspective fading distant peaks
+```
+
+**中文翻译：**
+
+```text
+主要目标与画面:一条巨龙从冰川上凸起的锯齿状冰刺之间掠过，拖着像萤火虫般在身后闪烁的火星，双翼展开，在阳光照射下的冰面投下阴影，低低掠过深邃的峡湾，腹部与水面的距离仅有一个翼展的宽度，两侧峭壁巍然耸立格式与外观:4K 分辨率，大画幅数码感光元件模拟，非球面50mm镜头，细腻颗粒质感模拟相机与滤镜:鼻端安装的万向稳定航拍平台，跟踪镜头 POV，1/8 Black Pro-Mist 滤镜用于高光处柔和光晕调色与色板:中性至冷色调（冰川蓝、板岩灰、浅雾白），仅在火星和反射阳光处使用暖色点缀光线与氛围:晚下午低角度自然散射光，薄雾中透出微弱光柱，远处山峰因空气透视而渐淡
+```
+
+**来源：** repo1/official-prompts.md
+
+## 例8-登山者呼喊 (Mountaineers Calling Out)
+
+**英文提示词：**
+
+```text
+Two mountain climbing explorers in red parkas stumble through fresh snow drifts in sequence, each calling out loudly into the white expanse as they climb toward a ridge
+```
+
+**中文翻译：**
+
+```text
+两名穿着红色羽绒服的登山探险者依次在新积雪中跌跌撞撞，每人向白茫茫的雪地大声呼喊，向山脊攀登
+```
+
+**来源：** repo1/official-prompts.md
+
+## 例9-排球小组活动 (Volleyball Group Activity)
+
+**英文提示词：**
+
+```text
+a group of people playing volleyball
+```
+
+**中文翻译：**
+
+```text
+一群人在打排球
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例10-豪华梅赛德斯广告 (Luxury Mercedes Ad)
+
+**英文提示词：**
+
+```text
+create a luxury ad for a black Mercedes Class G
+```
+
+**中文翻译：**
+
+```text
+为一辆黑色梅赛德斯G级制作奢华广告
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例11-索拉克普特 - 界面模拟 (Soraception - Interface Simulation)
+
+**英文提示词：**
+
+```text
+open Sora, type a prompt in, and generate video!
+```
+
+**中文翻译：**
+
+```text
+打开 Sora，输入提示，然后生成视频！
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例12-直播覆盖模拟 (Live Stream Overlay Simulation)
+
+**英文提示词：**
+
+```text
+A live stream overlay with the streamer's webcam in the corner, showing a screen recording of him typing a prompt into Sora, generating a video and reacting as the result plays
+```
+
+**中文翻译：**
+
+```text
+一个直播覆盖画面，主播的网络摄像头在角落，显示他在 Sora 中输入提示生成视频并在视频播放时做出反应的屏幕录制
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例13-包含Cameo头像的完整视频 (Full Video with Cameo Avatar)
+
+**英文提示词：**
+
+```text
+Testing out Sora 2... make an entire video using only prompts and have my cameo avatar say what I tell it to.
+```
+
+**中文翻译：**
+
+```text
+正在测试 Sora 2……只用提示词制作整个视频，并让我的客串头像说我告诉它的话。
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例14-历史说唱音乐剧 (Historical Rap Musical)
+
+**英文提示词：**
+
+```text
+star in a musical using American Revolution style. Topic of rap is 'The Innovator's Dilemma'
+```
+
+**中文翻译：**
+
+```text
+在一部采用美国独立战争风格的音乐剧中表演。说唱的主题是《创新者的窘境》
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例15-首席执行官说唱模仿 (CEO Rapper Parody)
+
+**英文提示词：**
+
+```text
+@sama is dressed like a rapper in the 2000s, he is talking about ain't nobody can come after him now that sora's free he gonna bankrupt all the other video companies, he's like what happened to that boy brrr
+```
+
+**中文翻译：**
+
+```text
+@sama穿得像2000年代的说唱歌手，他在说现在没人能追得上他了，既然Sora自由了，他要让其他所有视频公司破产，他还说那个男孩怎么了，哔哔哔
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例16-狼人变身 (Werewolf Transformation)
+
+**英文提示词：**
+
+```text
+Photorealistic Hipster, funny looking Man lays next to a camp fire staring up at the sky, it's a full moon, he looks at his hand it gets longer and grows hair, turning into the hand of a werewolf. His shoes break as his feet turn into giant werewolf feet, his nose gets longer, as he screams, his eyes turn and he if now finally a full werewolf, cinematic.
+```
+
+**中文翻译：**
+
+```text
+逼真的潮人，滑稽的男人躺在篝火旁仰望天空，满月高悬，他看着自己的手，手变长并长出毛发，变成狼人之手。他的鞋子在双脚变成巨大的狼人脚时破裂，鼻子变长，当他尖叫时，眼睛变了，他现在终于变成一个完整的狼人，电影般的画面。
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例17-爱情岛真人秀恶搞 (Love Island Reality Parody)
+
+**英文提示词：**
+
+```text
+Love Island reveal scene. A young woman sits on a plush villa sofa during a tense "Movie Night" scene. She watches a large TV screen showing grainy CCTV-style footage: Real-life Ronald McDonald, dashing into a room with real-life Wendy. The audience and woman are shocked
+```
+
+**中文翻译：**
+
+```text
+《爱情岛》揭示场景。一位年轻女子坐在别墅豪华的沙发上，正经历紧张的“电影之夜”场景。她看着大屏幕电视，电视显示着模糊的闭路电视风格的画面：现实生活中的麦当劳叔叔冲进房间，身边是现实生活中的温迪。观众和女子都感到震惊。
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例18-南方公园剧集 (South Park Episode)
+
+**英文提示词：**
+
+```text
+the gang discovers Waymo
+```
+
+**中文翻译：**
+
+```text
+这帮人发现了Waymo
+```
+
+**来源：** repo1/sora2-viral-prompts.md
+
+## 例19-大瑟尔海岸线 (Big Sur Coastline)
+
+**英文提示词：**
+
+```text
+Drone view of waves crashing against the rugged cliffs along Big Sur's garay point
+beach. The crashing blue waters create white-tipped waves, while the golden light
+of the setting sun illuminates the rocky shore. A small island with a lighthouse
+sits in the distance, and green shrubbery covers the cliff's edge. The steep drop
+from the road down to the beach is a dramatic feat, with the cliff's edges jutting
+out over the sea. This is a view that captures the raw beauty of the coast and the
+rugged landscape of the Pacific Coast Highway.
+```
+
+**中文翻译：**
+
+```text
+无人机视角俯瞰巨浪拍打比格瑟峡谷点海滩的崎岖悬崖。撞击的碧蓝海水形成白色浪尖，而落日的金色光芒照亮了岩石海岸。远处有一座小岛，上面矗立着灯塔，悬崖边缘覆盖着绿色灌木。从道路到海滩的陡峭下降堪称壮观，悬崖边缘向海中突出。这是一幅展现海岸原始之美和太平洋海岸公路崎岖景观的画面。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例20-海洋风暴 (Ocean Storm)
+
+**英文提示词：**
+
+```text
+Cinematic footage of massive waves during a storm in the North Atlantic. Dark, turbulent
+waters rise into 30-foot swells, white foam and spray flying off the crests. Low,
+ominous clouds race overhead. Camera mounted on ship bow, rising and falling with the
+swells, creating visceral sense of power and danger. Shot on weatherproof cinema camera,
+high shutter speed captures water droplets frozen in mid-air. Dramatic, documentary-style
+cinematography emphasizing nature's raw power.
+```
+
+**中文翻译：**
+
+```text
+北大西洋风暴中的巨浪电影画面。黑暗、汹涌的海水升腾成30英尺高的巨浪，浪尖上飞溅着白色泡沫和水花。低沉、不祥的云层在头顶掠过。摄像机安装在船首，随波起伏，带来强烈的力量与危险感。使用防风雨电影摄像机拍摄，高快门速度捕捉空中冻结的水滴。戏剧性、纪录片风格的摄影手法强调自然的原始力量。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例21-雪山山脉 (Snowy Mountain Range)
+
+**英文提示词：**
+
+```text
+Aerial drone shot soaring over a pristine mountain range at dawn. Fresh snow covers
+jagged peaks that catch the first pink and orange light of sunrise. Camera glides
+smoothly between peaks, revealing valleys filled with morning mist below. A frozen
+alpine lake reflects the colorful sky like a mirror. Pine trees at lower elevations
+are frosted with snow. Thin clouds drift between peaks. Cinematic, IMAX-quality
+landscape cinematography, shot on large format digital camera with exceptional clarity.
+```
+
+**中文翻译：**
+
+```text
+清晨，无人机航拍画面俯瞰一片原始的山脉。新雪覆盖着崎岖的山峰，迎接晨曦的第一抹粉色和橙色光芒。镜头在山峰间平稳滑动，展示下方被晨雾笼罩的山谷。一片冻结的高山湖如镜子般映照着多彩的天空。低海拔的松树被雪覆盖。薄云在山峰间飘动。电影感十足的IMAX级画质风景摄影，使用大画幅数字相机拍摄，画面异常清晰。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例22-秋天的森林小径 (Autumn Forest Path)
+
+**英文提示词：**
+
+```text
+Steadicam shot gliding down a winding forest path in peak autumn. Trees ablaze with
+red, orange, and yellow foliage create a natural tunnel overhead. Fallen leaves carpet
+the ground in thick layers, some lifted by a gentle breeze swirling around the camera.
+Shafts of warm afternoon sunlight pierce through gaps in the canopy, illuminating
+floating leaves and creating volumetric light beams. Camera moves forward at walking
+pace, smooth and steady, inviting viewer to take a peaceful journey. Shot on 35mm film
+with rich, saturated fall colors.
+```
+
+**中文翻译：**
+
+```text
+斯坦尼康镜头沿着蜿蜒的森林小径滑行，正值秋季最美时节。树木的红、橙、黄色叶子如火焰般燃烧，在头顶形成天然的隧道。厚厚的落叶铺满地面，微风轻拂，部分叶子在镜头周围翩翩起舞。温暖的午后阳光透过树冠间的缝隙，照亮飘落的叶子，形成立体的光束。镜头以行走的速度平稳前进，邀请观众踏上一段宁静的旅程。使用35毫米胶片拍摄，呈现出丰富而饱和的秋季色彩。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例23-东京夜街 (Tokyo Night Streets)
+
+**英文提示词：**
+
+```text
+A stylish woman walks down a Tokyo street filled with warm glowing neon and animated
+city signage. She wears a black leather jacket, a long red dress, and black boots, and
+carries a black purse. She wears sunglasses and red lipstick. She walks confidently and
+casually. The street is damp and reflective, creating a mirror effect of the colorful
+lights. Many pedestrians walk about.
+```
+
+**中文翻译：**
+
+```text
+一位时尚女性走在东京街道上，街道上充满温暖的霓虹灯和生动的城市招牌。她穿着黑色皮夹克、红色长裙和黑色靴子，手提黑色手提包。她戴着太阳镜，涂着红色口红。她自信且随意地行走。街道湿润并有反光，形成彩色灯光的镜像效果。许多行人来来往往。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例24-纽约市高峰时间 (New York City Rush Hour)
+
+**英文提示词：**
+
+```text
+Time-lapse of New York City intersection during evening rush hour. Camera locked in
+high position looking down at busy crosswalk. Yellow taxis, pedestrians, cyclists all
+flow through frame in accelerated motion. Traffic lights cycle from red to green.
+Street lights turn on as sky transitions from blue hour to night. Long exposure effect
+creates light trails from vehicles. Urban energy and rhythm of the city compressed into
+dynamic time-lapse. Sharp focus throughout, deep depth of field showing entire scene.
+```
+
+**中文翻译：**
+
+```text
+纽约市交叉路口在晚高峰期间的延时摄影。摄像机固定在高处俯拍繁忙的人行横道。黄色出租车、行人、骑行者都以加速的动作穿过画面。交通灯从红灯变为绿灯。随着天空从蓝色时刻过渡到夜晚，街灯亮起。长时间曝光效果创造出车辆的光轨。城市的活力和节奏浓缩在动态的延时摄影中。全景清晰，景深深，展示整个场景。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例25-葡萄园景观 (Vineyard Landscape)
+
+**英文提示词：**
+
+```text
+Breathtaking drone shot rising over Tuscan vineyard at golden hour. Camera starts low
+between rows of grapevines, their leaves deep green and grapes hanging full. Slowly
+ascends while rotating, revealing geometric patterns of planted rows stretching to
+horizon. Medieval stone farmhouse and cypress trees come into view. Rolling hills in
+background catch warm sunset light. Shadows lengthen across the landscape. Smooth,
+cinematic drone operation with slow, majestic movement. Colors rich and saturated,
+emphasizing Mediterranean warmth.
+```
+
+**中文翻译：**
+
+```text
+令人屏息的无人机镜头，从金色时刻的托斯卡纳葡萄园上空升起。镜头从葡萄藤之间的低处开始，它们的叶子深绿，葡萄挂满枝头。缓慢上升同时旋转，展现出延伸至地平线的整齐种植行列的几何图案。中世纪石制农舍和柏树映入眼帘。背景中的起伏山丘沐浴在温暖的夕阳光中。阴影在景观上延伸。无人机操作平稳、电影感强，运动缓慢而庄严。色彩丰富饱满，突显地中海的温暖气息。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例26-峡谷飞行 (Canyon Flight)
+
+**英文提示词：**
+
+```text
+FPV drone racing through narrow slot canyon in American Southwest. Camera flies at
+high speed between towering red rock walls, banking and twisting to navigate tight
+passages. Shafts of sunlight pierce down from the narrow opening above. Smooth rock
+walls blur past with incredible speed. Camera occasionally looks up showing thin strip
+of blue sky between walls. Adrenaline-pumping, dynamic flight cinematography. High
+frame rate captures crisp motion. Colors vibrant - deep red rocks, bright blue sky.
+```
+
+**中文翻译：**
+
+```text
+FPV 无人机在美国西南部的狭窄峡谷中飞行竞速。镜头以高速穿越高耸的红色岩壁，倾斜和扭转以通过狭窄的通道。阳光从上方狭窄的开口射入。光滑的岩壁以惊人的速度掠过。镜头偶尔向上拍摄，显示岩壁之间的一条细长蓝天。令人肾上腺素飙升的动态飞行摄影。高帧率捕捉清晰的动作画面。色彩鲜艳——深红色的岩石，明亮的蓝天。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例27-雷暴即将来临 (Thunderstorm Rolling In)
+
+**英文提示词：**
+
+```text
+Wide cinematic shot of a massive thunderstorm approaching across flat Kansas prairie.
+Dark, menacing wall of clouds advances toward camera with visible rain curtain beneath.
+Lightning flashes illuminate the storm's interior with brief, intense bursts. Wind whips
+through tall prairie grass in foreground, creating waves of motion. Last rays of sunlight
+break through at horizon, creating dramatic contrast between dark storm and golden light.
+Time slightly accelerated to show storm's progression. Shot on cinema camera with ND
+filters, high contrast, documentary weather cinematography.
+```
+
+**中文翻译：**
+
+```text
+跨越平坦堪萨斯大草原的巨大雷暴的广角电影镜头。黑暗、威胁感十足的云墙向镜头推进，下面可见雨幕。闪电照亮风暴内部，短暂而强烈。风在前景的高草间呼啸，形成波动的动态效果。地平线的最后一缕阳光穿透云层，营造出暗淡的风暴与金色光芒的戏剧性对比。时间略微加速以展示风暴的发展。使用带中性密度滤镜的电影摄影机拍摄，高对比度，纪录片风格的气象拍摄。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例28-晨雾峡谷 (Morning Fog Valley)
+
+**英文提示词：**
+
+```text
+Serene aerial shot of river valley filled with morning fog. Camera high above showing
+thick, white fog layer blanketing the valley floor like a cottony sea. Mountain peaks
+and hilltops poke through the fog layer like islands. Early morning sun creates soft,
+diffused light, edges of fog glowing golden. River barely visible as dark ribbon through
+the white. Complete stillness and tranquility. Slow, gentle camera movement floating
+peacefully above the scene. Meditative, ethereal quality. Colors muted and soft -
+whites, pale golds, soft blues.
+```
+
+**中文翻译：**
+
+```text
+宁静的航拍镜头显示被晨雾笼罩的河谷。镜头从高空俯瞰，厚厚的白色雾层像棉花般覆盖整个河谷地面。山峰和小丘突兀地穿过雾层，宛如岛屿。清晨的阳光创造出柔和的漫射光，雾的边缘泛着金色光芒。河流隐约可见，如白色之中的一条深色丝带。四周完全静谧宁静。镜头缓慢而轻柔地移动，平静地浮在景象之上。画面具有冥想般的空灵品质。色彩柔和、低调——白色、浅金色、柔和的蓝色。
+```
+
+**来源：** repo1/hyperrealism-landscapes.md
+
+## 例29-花样滑冰选手在有一只猫的情况下完成了三周半跳 (Figure Skater Performs A Triple Axle With A Cat On)
+
+**英文提示词：**
+
+```text
+figure skater performs a triple axle with a cat on her head
+```
+
+**中文翻译：**
+
+```text
+花样滑冰选手头上顶着一只猫完成了三周半跳
+```
+
+**来源：** repo2/README.md#1
+
+## 例30-动漫风格的烟花节，色彩鲜艳 (Anime Style Fireworks Festival With Vibrant Colors)
+
+**英文提示词：**
+
+```text
+Anime style fireworks festival with vibrant colors
+```
+
+**中文翻译：**
+
+```text
+动漫风格的烟花节，色彩鲜艳
+```
+
+**来源：** repo2/README.md#7
+
+## 例31-吉卜力动画风格的狗在探索魔法森林 (A Dog In Ghibli Animation Style Exploring A Magical Forest)
+
+**英文提示词：**
+
+```text
+A dog in Ghibli animation style exploring a magical forest
+```
+
+**中文翻译：**
+
+```text
+一个以吉卜力动画风格描绘的狗在探索神奇的森林
+```
+
+**来源：** repo2/README.md#8
+
+## 例32-一个黏土动画指挥指挥着一个黏土动画乐团 (A Claymation Conductor Conducts A Claymation Orchestra)
+
+**英文提示词：**
+
+```text
+A claymation conductor conducts a claymation orchestra
+```
+
+**中文翻译：**
+
+```text
+一个黏土动画指挥正在指挥一个黏土动画乐团
+```
+
+**来源：** repo2/README.md#11
+
+## 例33-动漫角色在戏剧性的光影和效果下觉醒 (Anime Character Awakening With Dramatic Lighting And Effects)
+
+**英文提示词：**
+
+```text
+Anime character awakening with dramatic lighting and effects
+```
+
+**中文翻译：**
+
+```text
+动漫角色在戏剧性的光影和特效下觉醒
+```
+
+**来源：** repo2/README.md#12
+
+## 例34-一个人做了一个后空翻 (A Guy Does A Backflip)
+
+**英文提示词：**
+
+```text
+a guy does a backflip
+```
+
+**中文翻译：**
+
+```text
+一个人做了一个后空翻
+```
+
+**来源：** repo2/README.md#2
+
+## 例35-维京人开战——北海发射（10.0S，冬季） (Vikings Go To War — North Sea Launch (10.0S, Winter)
+
+**英文提示词：**
+
+```text
+Vikings Go To War — North Sea Launch (10.0s, Winter cool daylight / early medieval). Clinker-built longships push off from a frozen shore
+```
+
+**中文翻译：**
+
+```text
+维京人出征——北海出发（10.0秒，冬日凉爽白昼 / 早期中世纪）。钉接长船从冰冻的海岸驶出
+```
+
+**来源：** repo2/README.md#3
+
+## 例36-两位登山探险者，穿着亮色技术外壳，脸上覆盖着冰霜 (Two Mountain Explorers In Bright Technical Shells, Ice Crusted Faces)
+
+**英文提示词：**
+
+```text
+Two mountain explorers in bright technical shells, ice crusted faces, eyes narrowed with urgency shout in the snow, one at a time
+```
+
+**中文翻译：**
+
+```text
+两名身穿鲜艳技术外壳的登山探险者，脸上结着冰霜，眼睛因紧迫而眯起，在雪地里轮流喊叫
+```
+
+**来源：** repo2/README.md#4
+
+## 例37-在一所著名大学中的学术环境与学生 (Academic Setting With Students In A Prestigious University)
+
+**英文提示词：**
+
+```text
+Academic setting with students in a prestigious university
+```
+
+**中文翻译：**
+
+```text
+在一所著名大学里的学术环境，学生们在那里学习
+```
+
+**来源：** repo2/README.md#13
+
+## 例38-大脚怪对他真的很友好，有点过于友好 (Bigfoot Is Really Kind To Him, A Little Too Kind)
+
+**英文提示词：**
+
+```text
+Bigfoot is really kind to him, a little too kind, like oddly kind. Bigfoot wants to hang out but he wants to hang too much
+```
+
+**中文翻译：**
+
+```text
+大脚怪对他真的很友好，有点过头了，奇怪地友好。大脚怪想一起玩，但他想玩的有点太多了
+```
+
+**来源：** repo2/README.md#5
+
+## 例39-一只名叫“天空”的宇航员金毛犬在星际间漂浮 (An Astronaut Golden Retriever Named 'Sora' Levitates Around An Intergalactic)
+
+**英文提示词：**
+
+```text
+An astronaut golden retriever named 'Sora' levitates around an intergalactic pup-themed space station
+```
+
+**中文翻译：**
+
+```text
+一只名叫“索拉”的宇航员金毛犬在一个银河系犬主题的太空站周围漂浮
+```
+
+**来源：** repo2/README.md#6
+
+## 例40-一条龙划过锯齿状的冰塔，翼尖旋涡剥离空气 (A Dragon Slicing Past Serrated Ice Spires, Wingtip Vortices Peeling)
+
+**英文提示词：**
+
+```text
+A dragon slicing past serrated ice spires, wingtip vortices peeling spindrift. The glacier's fractured sheet falls away to a cobalt fjord, with amber sun rim kissing frost on scales
+```
+
+**中文翻译：**
+
+```text
+一条龙划过锯齿般的冰塔，翼尖涡流剥落飞雪。冰川破碎的冰层坠入钴蓝色的峡湾，琥珀色的阳光轻抚鳞片上的霜。
+```
+
+**来源：** repo2/README.md#9
+
+## 例41-一只达尔马提亚犬表演奥林匹克体操动作 (A Dalmatian Performing Olympic Gymnastics Routines)
+
+**英文提示词：**
+
+```text
+A Dalmatian performing Olympic gymnastics routines
+```
+
+**中文翻译：**
+
+```text
+一只达尔马提亚犬在表演奥林匹克体操动作
+```
+
+**来源：** repo2/README.md#10
+
+## 例42-在魔幻奇幻场景中客串的人 (Person With Cameo In A Magical Fantasy Setting)
+
+**英文提示词：**
+
+```text
+Person with cameo in a magical fantasy setting
+```
+
+**中文翻译：**
+
+```text
+在魔幻幻想场景中的客串人物
+```
+
+**来源：** repo2/README.md#14
+
+## 例43-真人在动作场景中客串 (Real Person Cameo In An Action Scene)
+
+**英文提示词：**
+
+```text
+Real person cameo in an action scene
+```
+
+**中文翻译：**
+
+```text
+真人在动作场景中的客串
+```
+
+**来源：** repo2/README.md#15
+
+## 例44-探索超现实梦境环境的人 (Person Exploring A Surreal Dreamlike Environment)
+
+**英文提示词：**
+
+```text
+Person exploring a surreal dreamlike environment
+```
+
+**中文翻译：**
+
+```text
+在超现实梦境环境中探索的人
+```
+
+**来源：** repo2/README.md#16
+
+## 例45-身处充满活力的都市赛博朋克环境中的人 (Person In A Vibrant Urban Cyberpunk Setting)
+
+**英文提示词：**
+
+```text
+Person in a vibrant urban cyberpunk setting
+```
+
+**中文翻译：**
+
+```text
+生活在充满活力的都市赛博朋克环境中的人
+```
+
+**来源：** repo2/README.md#17
+
+## 例46-在异国丛林中的冒险场景 (Adventure Scene In An Exotic Jungle Location)
+
+**英文提示词：**
+
+```text
+Adventure scene in an exotic jungle location
+```
+
+**中文翻译：**
+
+```text
+在异国丛林中的冒险场景
+```
+
+**来源：** repo2/README.md#18
+
+## 例47-温暖而宜人的冬季小屋场景，带有逼真的光影效果 (Warm And Inviting Winter Cabin Scene With Realistic Lighting And)
+
+**英文提示词：**
+
+```text
+Warm and inviting winter cabin scene with realistic lighting and atmosphere
+```
+
+**中文翻译：**
+
+```text
+温暖宜人的冬季小木屋场景，具有逼真的光照和氛围
+```
+
+**来源：** repo2/README.md#19
+
+## 例48-在水下海洋环境中的人 (Person In An Underwater Oceanic Environment)
+
+**英文提示词：**
+
+```text
+Person in an underwater oceanic environment
+```
+
+**中文翻译：**
+
+```text
+在水下海洋环境中的人
+```
+
+**来源：** repo2/README.md#20
+
+## 例49-一个 24 岁女性眼睛的特写镜头 (Extreme Close Up Of A 24 Year Old Woman'S Eye)
+
+**英文提示词：**
+
+```text
+Extreme close up of a 24 year old woman's eye blinking, standing in Marrakech during magic hour, cinematic film shot in 70mm, depth of field, vivid colors, cinematic.
+```
+
+**中文翻译：**
+
+```text
+极近特写，一位24岁女性的眼睛眨动，她站在马拉喀什的魔幻时刻，70毫米电影镜头拍摄，景深感十足，色彩鲜艳，具有电影感。
+```
+
+**来源：** repo2/README.md#23
+
+## 例50-美丽的雪天东京市熙熙攘攘。摄像机移动。 (A Beautiful, Snowy Tokyo City Is Bustling. The Camera Moves)
+
+**英文提示词：**
+
+```text
+A beautiful, snowy Tokyo city is bustling. The camera moves through the bustling city street, following several people enjoying the beautiful snowy weather and shopping at nearby stalls.
+```
+
+**中文翻译：**
+
+```text
+美丽的东京城市被雪覆盖，熙熙攘攘。镜头穿过繁忙的城市街道，跟随几个人享受美丽的雪景和在附近摊位购物。
+```
+
+**来源：** repo2/README.md#24
+
+## 例51-美丽的雪东京市熙熙攘攘。镜头穿行其中 (Beautiful, Snowy Tokyo City Is Bustling. The Camera Moves Through)
+
+**英文提示词：**
+
+```text
+Beautiful, snowy Tokyo city is bustling. The camera moves through the bustling city street, following several people enjoying the beautiful snowy weather and shopping at nearby stalls. Gorgeous sakura petals are flying through the wind along with snowflakes.
+```
+
+**中文翻译：**
+
+```text
+美丽的雪天东京市熙熙攘攘。镜头穿过繁忙的城市街道，跟随几个人享受美丽的雪天并在附近的摊位购物。美丽的樱花花瓣随风飘舞，伴随着雪花飞舞。
+```
+
+**来源：** repo2/README.md#26
+
+## 例52-相机直接面向意大利布拉诺的五彩建筑。 (The Camera Directly Faces Colorful Buildings In Burano Italy. An)
+
+**英文提示词：**
+
+```text
+The camera directly faces colorful buildings in Burano Italy. An adorable dalmation looks through a window on a building on the ground floor. Many people are walking and cycling along the canal streets in front of the buildings.
+```
+
+**中文翻译：**
+
+```text
+相机直接对着意大利布拉诺色彩斑斓的建筑。一只可爱的斑点狗从一栋建筑底层的窗户里探出头来。许多人在建筑前的运河街道上行走和骑自行车。
+```
+
+**来源：** repo2/README.md#27
+
+## 例53-赛博朋克背景下的机器人生活故事 (The Story Of A Robot'S Life In A Cyberpunk Setting)
+
+**英文提示词：**
+
+```text
+The story of a robot's life in a cyberpunk setting.
+```
+
+**中文翻译：**
+
+```text
+一个关于机器人在赛博朋克环境中生活的故事。
+```
+
+**来源：** repo2/README.md#30
+
+## 例54-一段带有中国龙的中国农历新年庆祝视频 (A Chinese Lunar New Year Celebration Video With Chinese Dragon)
+
+**英文提示词：**
+
+```text
+A Chinese Lunar New Year celebration video with Chinese Dragon.
+```
+
+**中文翻译：**
+
+```text
+一段有中国龙的中国农历新年庆祝视频。
+```
+
+**来源：** repo2/README.md#31
+
+## 例55-参观一个拥有许多美丽作品的艺术画廊 (Tour Of An Art Gallery With Many Beautiful Works Of)
+
+**英文提示词：**
+
+```text
+Tour of an art gallery with many beautiful works of art in different styles.
+```
+
+**中文翻译：**
+
+```text
+参观一个艺术画廊，里面有许多不同风格的美丽艺术作品。
+```
+
+**来源：** repo2/README.md#32
+
+## 例56-一个玻璃球的特写镜头，有 (A Close Up View Of A Glass Sphere That Has)
+
+**英文提示词：**
+
+```text
+A close up view of a glass sphere that has a zen garden within it. There is a small dwarf in the sphere who is raking the zen garden and creating patterns in the sand.
+```
+
+**中文翻译：**
+
+```text
+一个玻璃球的特写视图，里面有一个禅意花园。球内有一个小矮人，他正在耙弄禅园，在沙子上创造图案。
+```
+
+**来源：** repo2/README.md#33
+
+## 例57-蓝色时刻的圣托里尼航拍景观，展示了 (Aerial View Of Santorini During The Blue Hour, Showcasing The)
+
+**英文提示词：**
+
+```text
+Aerial view of Santorini during the blue hour, showcasing the stunning architecture of white Cycladic buildings with blue domes. The caldera views are breathtaking, and the lighting creates a beautiful, serene atmosphere.
+```
+
+**中文翻译：**
+
+```text
+蓝调时分的圣托里尼鸟瞰，展示了白色基克拉泽建筑和蓝色圆顶的迷人建筑风格。火山口的景色令人叹为观止，光线营造出美丽而宁静的氛围。
+```
+
+**来源：** repo2/README.md#34
+
+## 例58-培养皿中生长着一片竹林 (A Petri Dish With A Bamboo Forest Growing Within It)
+
+**英文提示词：**
+
+```text
+A petri dish with a bamboo forest growing within it that has tiny red pandas running around.
+```
+
+**中文翻译：**
+
+```text
+一个培养皿里长着竹林，小小的红熊猫在其中奔跑。
+```
+
+**来源：** repo2/README.md#35
+
+## 例59-相机围绕一大堆老式电视旋转 (The Camera Rotates Around A Large Stack Of Vintage Televisions)
+
+**英文提示词：**
+
+```text
+The camera rotates around a large stack of vintage televisions all showing different programs — 1950s sci-fi movies, horror movies, news, static, a 1970s sitcom, etc, set inside a large New York museum gallery.
+```
+
+**中文翻译：**
+
+```text
+相机围绕着一大堆老式电视旋转，每台电视播放的节目都不同——1950年代的科幻电影、恐怖电影、新闻、雪花点、1970年代的情景喜剧等，这些都设置在纽约一家大型博物馆画廊内。
+```
+
+**来源：** repo2/README.md#36
+
+## 例60-一个小而圆、毛茸茸的生物的3D动画，长着大大的… (3D Animation Of A Small, Round, Fluffy Creature With Big)
+
+**英文提示词：**
+
+```text
+3D animation of a small, round, fluffy creature with big, expressive eyes explores a vibrant, enchanted forest. The creature, a whimsical blend of a rabbit and a squirrel, has soft blue fur and a bushy, striped tail. It hops along a sparkling stream, its eyes wide with wonder. The forest is alive with magical elements: flowers that glow and change colors, trees with leaves in shades of purple and silver, and small floating lights that resemble fireflies. The creature stops to interact playfully with a group of tiny, fairy-like beings dancing around a mushroom ring. The creature looks up in awe at a large, glowing tree that seems to be the heart of the forest.
+```
+
+**中文翻译：**
+
+```text
+一个小巧、圆润、毛茸茸的生物拥有大而富有表情的眼睛，在充满活力的魔法森林中探险的3D动画。这只生物是兔子和松鼠的奇幻结合体，拥有柔软的蓝色毛发和蓬松的条纹尾巴。它沿着闪闪发光的小溪跳跃，眼中充满了好奇与惊奇。森林中充满了魔法元素：闪光并变色的花朵、叶片呈紫色和银色的树木，以及像萤火虫般漂浮的小灯光。生物停下来与一群围绕蘑菇环舞蹈的小巧、仙灵般的生物互动嬉戏。它仰望着一棵巨大的、发光的树，那棵树似乎是森林的核心。
+```
+
+**来源：** repo2/README.md#37
+
+## 例61-一只卡通袋鼠跳迪斯科舞 (A Cartoon Kangaroo Disco Dances)
+
+**英文提示词：**
+
+```text
+A cartoon kangaroo disco dances.
+```
+
+**中文翻译：**
+
+```text
+一只卡通袋鼠跳迪斯科舞。
+```
+
+**来源：** repo2/README.md#38
+
+## 例62-一个二十多岁的年轻人坐在一张 (A Young Man At His 20S Is Sitting On A)
+
+**英文提示词：**
+
+```text
+A young man at his 20s is sitting on a piece of cloud in the sky, reading a book.
+```
+
+**中文翻译：**
+
+```text
+一个二十多岁的小伙子正坐在天空中的一片云上看书。
+```
+
+**来源：** repo2/README.md#39
+
+## 例63-加利福尼亚淘金热时期的历史影像 (Historical Footage Of California During The Gold Rush)
+
+**英文提示词：**
+
+```text
+Historical footage of California during the gold rush.
+```
+
+**中文翻译：**
+
+```text
+加利福尼亚淘金热时期的历史影像。
+```
+
+**来源：** repo2/README.md#40
+
+## 例64-纸艺水下场景的特写视图。一个 (A Close Up View Of A Papercraft Underwater Scene. A)
+
+**英文提示词：**
+
+```text
+A close up view of a papercraft underwater scene. A blue whale swims through the frame, with cardboard fish and sea creatures drifting alongside it.
+```
+
+**中文翻译：**
+
+```text
+纸艺水下场景的特写镜头。一只蓝鲸游过画面，纸板鱼和海洋生物随着它漂浮。
+```
+
+**来源：** repo2/README.md#41
+
+## 例65-两个海盗船互相战斗的逼真特写视频 (Photorealistic Closeup Video Of Two Pirate Ships Battling Each Other)
+
+**英文提示词：**
+
+```text
+Photorealistic closeup video of two pirate ships battling each other as they sail inside a cup of coffee.
+```
+
+**中文翻译：**
+
+```text
+逼真的特写视频，两艘海盗船在一杯咖啡中航行并互相战斗。
+```
+
+**来源：** repo2/README.md#42
+
+## 例66-一位梳着整齐灰发的祖母站在后面 (A Grandmother With Neatly Combed Grey Hair Stands Behind A)
+
+**英文提示词：**
+
+```text
+A grandmother with neatly combed grey hair stands behind a colorful birthday cake with numerous candles at a wood dining room table, expression is one of pure joy and happiness, with a happy glow in her eye. She leans forward and blows out the candles with a gentle puff, the cake has pink frosting and sprinkles and the candles cease to flicker, the grandmother wears a light blue blouse adorned with floral patterns, several happy friends and family sitting at the table can be seen celebrating, out of focus. The scene is beautifully captured, cinematic, showing a 3/4 view of the grandmother and the dining room. Warm color tones and soft lighting enhance the mood.
+```
+
+**中文翻译：**
+
+```text
+一位头发梳理整齐的灰发祖母站在木质餐桌旁，面前摆放着一款装饰丰富、插满蜡烛的彩色生日蛋糕，她的表情充满纯粹的喜悦和幸福，眼中闪烁着快乐的光芒。她向前倾身，轻轻一吹，蜡烛熄灭，蛋糕上粉红色的糖霜和糖屑散落。祖母穿着一件饰有花卉图案的浅蓝色衬衫，桌旁还有几位愉快的朋友和家人正在庆祝（画面模糊）。场景被精美地捕捉，具有电影感，展示了祖母和餐厅的三分之四视角。温暖的色调和柔和的灯光增强了整体氛围。
+```
+
+**来源：** repo2/README.md#43
+
+## 例67-镜头跟随一辆白色复古 SUV 从后面 (The Camera Follows Behind A White Vintage Suv With A)
+
+**英文提示词：**
+
+```text
+The camera follows behind a white vintage SUV with a black roof rack as it speeds up a steep dirt road surrounded by pine trees on a steep mountain slope, dust kicks up from its tires, the sunlight shines on the SUV as it speeds along the dirt road, casting a warm glow over the scene. The dirt road curves gently into the distance, with no other cars or vehicles in sight. The trees on either side of the road are redwoods, with patches of greenery scattered throughout. The car is seen from the rear following the curve with ease, making it seem as if it is on a rugged drive through the rugged terrain. The dirt road itself is surrounded by steep hills and mountains, with a clear blue sky above with wispy clouds.
+```
+
+**中文翻译：**
+
+```text
+镜头跟随一辆白色复古SUV，它装有黑色车顶行李架，沿着一条陡峭的土路飞驰而上，两旁是陡峭山坡上的松树，轮胎扬起尘土。阳光洒在SUV上，为场景投射出温暖的光芒。土路缓缓蜿蜒向远处，看不到其他车辆。道路两侧的树木是红木，间或点缀着绿色植被。从后方可以看到汽车从容地跟随道路的弯曲，仿佛正在崎岖地驾车穿越险峻的地形。土路本身被陡峭的山坡和群山环绕，蓝天清澈，飘着几丝薄云。
+```
+
+**来源：** repo2/README.md#44
+
+## 例68-火车窗里的倒影，列车行驶中 (Reflections In The Window Of A Train Traveling Through The)
+
+**英文提示词：**
+
+```text
+Reflections in the window of a train traveling through the Tokyo suburbs.
+```
+
+**中文翻译：**
+
+```text
+穿越东京郊区的火车窗户中的倒影。
+```
+
+**来源：** repo2/README.md#45
+
+## 例69-无人机摄像机环绕一座美丽的历史教堂建造 (A Drone Camera Circles Around A Beautiful Historic Church Built)
+
+**英文提示词：**
+
+```text
+A drone camera circles around a beautiful historic church built on a rocky outcropping along the Amalfi Coast, the view showcases historic and magnificent architectural details and tiered pathways and patios, waves are seen crashing against the rocks below as the view overlooks the horizon of the coastal waters and hilly landscapes of the Amalfi Coast Italy, several distant people are seen walking and enjoying vistas on patios of the dramatic ocean views, the warm glow of the afternoon sun creates a magical and romantic feeling to the scene, the view is stunning captured with beautiful photography.
+```
+
+**中文翻译：**
+
+```text
+一架无人机摄像机环绕着位于阿马尔菲海岸岩石突出部分上的一座美丽的历史教堂，画面展示了历史悠久而宏伟的建筑细节以及分层的路径和露台，可以看到海浪拍打着下面的岩石，视野俯瞰阿马尔菲海岸意大利沿海的水域和丘陵景观的地平线，远处有几个人在露台上行走并欣赏壮丽的海景，下午阳光的温暖光辉为场景增添了神奇而浪漫的氛围，这一景象通过精美的摄影拍摄下来，令人叹为观止。
+```
+
+**来源：** repo2/README.md#46
+
+## 例70-一窝金毛寻回犬小狗在雪地里玩耍 (A Litter Of Golden Retriever Puppies Playing In The Snow)
+
+**英文提示词：**
+
+```text
+A litter of golden retriever puppies playing in the snow. Their heads pop out of the snow, covered in.
+```
+
+**中文翻译：**
+
+```text
+一窝金毛猎犬小狗在雪地里玩耍。它们的头从雪中冒出来，满是雪花。
+```
+
+**来源：** repo2/README.md#47
+
+## 例71-冲印式摄影：一个人跑步，电影感影片拍摄 (Step-Print Photography Of A Person Running, Cinematic Film Shot In)
+
+**英文提示词：**
+
+```text
+Step-print photography of a person running, cinematic film shot in 35mm.
+```
+
+**中文翻译：**
+
+```text
+使用阶梯曝光拍摄的奔跑人物摄影，35毫米电影胶片拍摄。
+```
+
+**来源：** repo2/README.md#48
+
+## 例72-海洋上的自行车比赛，参赛选手是不同的动物 (A Bicycle Race On Ocean With Different Animals As Athletes)
+
+**英文提示词：**
+
+```text
+A bicycle race on ocean with different animals as athletes riding the bicycles with drone camera view.
+```
+
+**中文翻译：**
+
+```text
+一场在海洋上进行的自行车赛，不同的动物作为运动员骑着自行车，从无人机视角观看。
+```
+
+**来源：** repo2/README.md#49
+
+## 例73-施工现场的移轴摄影，场地充满了工人和设备 (Tiltshift Of A Construction Site Filled With Workers, Equipment, And)
+
+**英文提示词：**
+
+```text
+Tiltshift of a construction site filled with workers, equipment, and heavy machinery.
+```
+
+**中文翻译：**
+
+```text
+倾斜移轴摄影的建筑工地，工地上充满了工人、设备和重型机械。
+```
+
+**来源：** repo2/README.md#50
+
+## 例74-一群纸飞机在茂密的丛林中飞舞 (A Flock Of Paper Airplanes Flutters Through A Dense Jungle)
+
+**英文提示词：**
+
+```text
+A flock of paper airplanes flutters through a dense jungle, weaving around trees as if they were migrating birds.
+```
+
+**中文翻译：**
+
+```text
+一群纸飞机在茂密的丛林中飞舞，绕过树木，就像迁徙的鸟群一样。
+```
+
+**来源：** repo2/README.md#51
+
+## 例75-一只猫叫醒正在睡觉的主人，要求吃早餐。 (A Cat Waking Up Its Sleeping Owner Demanding Breakfast. The)
+
+**英文提示词：**
+
+```text
+A cat waking up its sleeping owner demanding breakfast. The owner tries to ignore the cat, but the cat tries new tactics and finally the owner pulls out a secret stash of treats from under the pillow to hold the cat off a little longer.
+```
+
+**中文翻译：**
+
+```text
+一只猫叫醒正在睡觉的主人，要求吃早餐。主人试图忽视猫咪，但猫又尝试了新的策略，最后主人从枕头底下拿出一小袋秘密零食，让猫咪再等等。
+```
+
+**来源：** repo2/README.md#52
+
+## 例76-京那巴当岸河上的婆罗洲野生动物 (Borneo Wildlife On The Kinabatangan River)
+
+**英文提示词：**
+
+```text
+Borneo wildlife on the Kinabatangan River.
+```
+
+**中文翻译：**
+
+```text
+京那巴当岸河流上的婆罗洲野生动物。
+```
+
+**来源：** repo2/README.md#53
+
+## 例77-一名中国男子站在中国的群山中练太极 (A Chinese Man Stands In Chinese Mountains And Makes Tai)
+
+**英文提示词：**
+
+```text
+A Chinese man stands in Chinese mountains and makes Tai Chi moves, facial closeup.
+```
+
+**中文翻译：**
+
+```text
+一名中国男子站在中国的山中练习太极，面部特写。
+```
+
+**来源：** repo2/README.md#54
+
+## 例78-一列蒸汽火车驶过华丽的大理石和黄铜装饰 (A Steam Train Passes Through An Ornate Marble And Brass)
+
+**英文提示词：**
+
+```text
+A steam train passes through an ornate marble and brass station, people are waiting at the platforms as the train passes by, sparks flying from the train as it moves. Golden hour light, soft shadows, vintage color grading.
+```
+
+**中文翻译：**
+
+```text
+一列蒸汽火车穿过一座华丽的大理石和黄铜车站，乘客们在站台上等候，火车经过时火花四溅。金色时光的光线，柔和的阴影，复古色调。
+```
+
+**来源：** repo2/README.md#55
+
+## 例79-一个灰发胡须男子的特写镜头 (An Extreme Close-Up Of An Gray-Haired Man With A Beard)
+
+**英文提示词：**
+
+```text
+An extreme close-up of an gray-haired man with a beard in his 60s, he is deep in thought pondering the history of the universe as he sits at a cafe in Paris, his eyes focus on people offscreen as they walk as he sits mostly motionless, he is dressed in a wool coat suit coat with a button-down shirt, he wears a brown beret and glasses and has a very professorial appearance, and the end he offers a subtle closed-mouth smile as if he found the answer to the mystery of life, the lighting is very cinematic with the golden light and the Parisian streets and city in the background, depth of field, cinematic 35mm film.
+```
+
+**中文翻译：**
+
+```text
+一个灰发胡子的六十多岁男子的极近特写，他正沉思着宇宙的历史，坐在巴黎的一家咖啡馆里，他的目光聚焦在画面外走动的人身上，自己几乎一动不动。他身穿羊毛大衣和西装外套，内搭衬衫，戴着棕色贝雷帽和眼镜，看起来非常有教授气质。在画面末，他微微闭嘴微笑，仿佛找到了人生奥秘的答案。光线非常电影感，金色光芒洒落，背景是巴黎街道和城市，景深明显，采用电影感的35毫米胶片风格。
+```
+
+**来源：** repo2/README.md#56
+
+## 例80-一只大橙色章鱼被看到在海底休息 (A Large Orange Octopus Is Seen Resting On The Bottom)
+
+**英文提示词：**
+
+```text
+A large orange octopus is seen resting on the bottom of the ocean floor, blending in with the sandy and rocky terrain. Its tentacles are spread out around its body, and its eyes are closed. The octopus is unaware of a king crab that is crawling towards it from behind a rock, its claws raised and ready to attack. The crab is brown and spiny, with long legs and antennae. The scene is captured from a wide angle, showing the vastness and depth of the ocean. The water is clear and blue, with rays of sunlight filtering through. The shot is sharp and crisp, with a high dynamic range. The octopus and the crab are in focus, while the background is slightly blurred, creating a depth of field effect.
+```
+
+**中文翻译：**
+
+```text
+一只巨大的橙色章鱼被看到休息在海底，融入了沙质和岩石的地形中。它的触手在身体周围伸展开，双眼紧闭。章鱼没有注意到一只从岩石后面爬向它的帝王蟹，蟹的钳子扬起，准备攻击。螃蟹呈棕色，有刺，腿和触角都很长。画面以广角拍摄，展示了海洋的辽阔和深邃。水清澈而湛蓝，阳光的光线透过水面照射下来。画面清晰锐利，动态范围广。章鱼和螃蟹都在焦点上，而背景略微模糊，营造出景深效果。
+```
+
+**来源：** repo2/README.md#57
+
+## 例81-音乐家在舞台上表演的生动场景，周围环绕着 (A Vibrant Scene Of A Musician Performing On Stage, Surrounded)
+
+**英文提示词：**
+
+```text
+A vibrant scene of a musician performing on stage, surrounded by a mesmerized audience. The stage is bathed in colorful spotlights and the musician plays an electric guitar with passion and energy. The crowd is cheering and dancing, creating an electrifying atmosphere. The camera pans around the stage, capturing the energy and excitement of the performance from different angles.
+```
+
+**中文翻译：**
+
+```text
+一个充满活力的场景：一位音乐家在舞台上表演，周围是着迷的观众。舞台被五彩斑斓的灯光照亮，音乐家充满激情与活力地演奏电吉他。观众欢呼跳舞，营造出电力十足的氛围。摄像机环绕舞台拍摄，从不同角度捕捉表演的能量与激动人心的场面。
+```
+
+**来源：** repo2/README.md#58
+
+## 例82-一只中等体型的混种狗，毛色混合了棕色和 (A Medium-Sized Mixed-Breed Dog, With A Mix Of Brown And)
+
+**英文提示词：**
+
+```text
+A medium-sized mixed-breed dog, with a mix of brown and black fur, is seen running through a large, open field. The dog is captured in mid-stride, with all four legs off the ground, showcasing its speed and agility. The field is filled with tall green grass that sways gently in the wind, and wildflowers dot the landscape, adding splashes of color. The background features a line of trees, their leaves rustling softly, and a partly cloudy sky above. The sunlight casts a warm, golden glow over the scene, highlighting the dog's fur and creating dynamic shadows. The shot is taken with a steady cam, keeping the dog in focus while the background blurs slightly, emphasizing the motion and energy of the moment.
+```
+
+**中文翻译：**
+
+```text
+一只中等体型的混种狗，毛色混合了棕色和黑色，正在一片宽阔的开阔地奔跑。狗在跃起半空时被捕捉到，四条腿全都离地，展现出它的速度和敏捷。田野里长满高高的绿草，随风轻轻摇曳，野花点缀其间，为景色增添了色彩。背景是一排树木，树叶轻轻沙沙作响，天空部分多云。阳光洒下温暖的金色光辉，照亮狗的毛发，并创造出动感的阴影。镜头使用稳定拍摄，将狗保持在焦点中，而背景略微模糊，突出了这一瞬间的运动与活力。
+```
+
+**来源：** repo2/README.md#59
+
+## 例83-夜晚的反乌托邦未来城市景观，霓虹灯反射 (A Dystopian Future Cityscape At Night, Neon Lights Reflecting Off)
+
+**英文提示词：**
+
+```text
+A dystopian future cityscape at night, neon lights reflecting off wet streets, towering skyscrapers piercing through thick smog. A lone figure in a long coat walks through the rain-soaked streets, the camera follows from behind, capturing the gritty, atmospheric environment with deep shadows and vibrant neon colors. Cinematic, shot in 4K, inspired by Blade Runner.
+```
+
+**中文翻译：**
+
+```text
+夜晚的反乌托邦未来城市景观，霓虹灯在湿漉漉的街道上反射，高耸的摩天大楼穿透浓厚的雾霾。一位身穿长外套的孤独身影走在雨湿的街道上，镜头从背后跟随，捕捉到充满质感的氛围环境，深邃的阴影与鲜艳的霓虹色彩相映成趣。电影感十足，4K拍摄，灵感来自《银翼杀手》。
+```
+
+**来源：** repo2/README.md#60
+
+## 例84-穿越生机勃勃的珊瑚礁的水下探险，鱼群 (An Underwater Expedition Through A Vibrant Coral Reef, Schools Of)
+
+**英文提示词：**
+
+```text
+An underwater expedition through a vibrant coral reef, schools of tropical fish swimming gracefully. Sunlight filters through the water, creating dancing patterns of light. A sea turtle glides majestically through the frame. Shot with underwater cinematography techniques, crystal clear water, rich colors.
+```
+
+**中文翻译：**
+
+```text
+一次穿越色彩斑斓的珊瑚礁的水下探险，成群的热带鱼优雅地游动。阳光透过水面，形成舞动的光影图案。一只海龟在画面中庄严地滑行。采用水下摄影技术拍摄，水质清澈，色彩丰富。
+```
+
+**来源：** repo2/README.md#61
+
+## 例85-繁忙都市路口高峰时段的延时摄影 (A Time-Lapse Of A Bustling City Intersection At Rush Hour)
+
+**英文提示词：**
+
+```text
+A time-lapse of a bustling city intersection at rush hour, people crossing in all directions, traffic lights changing, vehicles flowing. The camera is positioned high above, capturing the organized chaos from a bird's eye view. Golden hour lighting, long shadows, urban energy.
+```
+
+**中文翻译：**
+
+```text
+一个繁忙城市十字路口的延时摄影，高峰时段，人们在各个方向穿行，红绿灯变换，车辆川流不息。摄像机位于高处，从鸟瞰视角捕捉这有序的混乱。黄金时刻的光线，长长的影子，都市的活力。
+```
+
+**来源：** repo2/README.md#62
+
+## 例86-一只雄伟的鹰在日出时穿越山谷飞翔 (A Majestic Eagle Soaring Through A Mountain Canyon At Sunrise)
+
+**英文提示词：**
+
+```text
+A majestic eagle soaring through a mountain canyon at sunrise, wings spread wide catching the golden light. The camera flies alongside the eagle, matching its graceful movements. Snow-capped peaks in the background, morning mist in the valleys below. Cinematic wildlife photography, 4K, inspiring and epic.
+```
+
+**中文翻译：**
+
+```text
+一只雄伟的老鹰在日出时分翱翔于山谷之间，展开的双翼捕捉着金色的光芒。摄像机与老鹰并行飞行，跟随其优雅的动作。背景是白雪覆盖的山峰，山谷中笼罩着晨雾。电影风格的野生动物摄影，4K画质，令人振奋而壮丽。
+```
+
+**来源：** repo2/README.md#63
+
+## 例87-一位专业厨师在传统的日本餐厅制作寿司 (A Professional Chef Preparing Sushi In A Traditional Japanese Restaurant)
+
+**英文提示词：**
+
+```text
+A professional chef preparing sushi in a traditional Japanese restaurant, hands moving with precision and grace. Close-up shots of fresh fish being sliced, rice being shaped, ingredients being carefully arranged. Soft natural lighting, minimalist aesthetic, focus on craftsmanship and detail.
+```
+
+**中文翻译：**
+
+```text
+一位专业厨师在传统的日本餐馆里制作寿司，双手动作精确且优雅。特写镜头展示新鲜鱼片被切割、米饭被塑形、食材被精心摆放。柔和的自然光，极简美学，注重工艺与细节。
+```
+
+**来源：** repo2/README.md#64
+
+## 例88-在雾气缭绕的竹林中平静的冥想场景 (A Peaceful Meditation Scene In A Misty Bamboo Forest At)
+
+**英文提示词：**
+
+```text
+A peaceful meditation scene in a misty bamboo forest at dawn. A monk in orange robes sits in lotus position on a stone platform. Rays of sunlight pierce through the fog, creating an ethereal atmosphere. Gentle breeze moves the bamboo, birds chirping softly. Serene, spiritual, contemplative mood.
+```
+
+**中文翻译：**
+
+```text
+黎明时分的薄雾竹林中，一幅宁静的冥想场景。一位身穿橙色袈裟的僧侣盘坐在石台上。阳光穿透雾气，营造出空灵的氛围。微风轻拂竹叶，鸟儿轻声啁啾。宁静、灵性、沉思的氛围。
+```
+
+**来源：** repo2/README.md#65
+
+## 例89-穿越狭窄欧洲街道的高速汽车追逐，摄像机已安装 (A High-Speed Car Chase Through Narrow European Streets, Camera Mounted)
+
+**英文提示词：**
+
+```text
+A high-speed car chase through narrow European streets, camera mounted on the pursuing vehicle. Sharp turns, close calls with pedestrians, tires screeching. The architecture blurs past, historic buildings and cobblestone streets. Adrenaline-pumping action sequence, dynamic camera work, intense energy.
+```
+
+**中文翻译：**
+
+```text
+一场高速汽车追逐穿过狭窄的欧洲街道，摄像机安装在追车上。急转弯，险些撞到行人，轮胎尖叫。建筑物迅速掠过，历史建筑和鹅卵石街道。充满肾上腺素的动作场面，动态摄影，强烈的能量感。
+```
+
+**来源：** repo2/README.md#66
+
+## 例90-一个充满漂浮书籍、发光手稿和螺旋结构的魔法图书馆 (A Magical Library With Floating Books, Glowing Manuscripts, And Spiral)
+
+**英文提示词：**
+
+```text
+A magical library with floating books, glowing manuscripts, and spiral staircases leading to impossible heights. A young wizard in robes walks through, trailing sparkles of magic. Books flutter open, revealing illuminated pages. Fantasy aesthetic, warm golden lighting, sense of wonder and mystery.
+```
+
+**中文翻译：**
+
+```text
+一个魔法图书馆，书本漂浮，手稿发光，螺旋楼梯通向无法到达的高度。一位穿着长袍的年轻巫师走过，身后拖着魔法火花。书籍翻开，展现出光彩照人的页面。奇幻美学，温暖的金色灯光，充满奇迹与神秘的感觉。
+```
+
+**来源：** repo2/README.md#67
+
+## 例91-穿越人体血液的微观旅程：红细胞 (A Microscopic Journey Through The Human Bloodstream, Red Blood Cells)
+
+**英文提示词：**
+
+```text
+A microscopic journey through the human bloodstream, red blood cells flowing through veins, white blood cells attacking bacteria. The camera travels through arteries and capillaries, showing the inner workings of the circulatory system. Educational, scientifically accurate, beautifully rendered in 3D.
+```
+
+**中文翻译：**
+
+```text
+一次穿越人体血液循环的显微之旅，红细胞在静脉中流动，白细胞攻击细菌。镜头穿过动脉和毛细血管，展示循环系统的内部运作。教育性强，科学准确，以精美的3D效果呈现。
+```
+
+**来源：** repo2/README.md#68
+
+## 例92-一支爵士四重奏在昏暗、烟雾弥漫的俱乐部表演 (A Jazz Quartet Performing In A Dimly Lit, Smoke-Filled Club)
+
+**英文提示词：**
+
+```text
+A jazz quartet performing in a dimly lit, smoke-filled club. Saxophone player takes a solo, fingers dancing on the keys. Drummer keeps the rhythm, bass player nods along. Audience members sway in the background. Moody lighting, film noir atmosphere, vintage 1950s aesthetic.
+```
+
+**中文翻译：**
+
+```text
+一支爵士四重奏在昏暗、烟雾弥漫的俱乐部表演。萨克斯手独奏，手指在琴键上舞动。鼓手保持节奏，贝斯手随之点头。观众在背景中轻轻摇摆。情绪化的灯光，黑色电影氛围，复古的1950年代美学。
+```
+
+**来源：** repo2/README.md#69
+
+## 例93-中世纪的铁匠铺，锤子敲打炽热的铁 (A Blacksmith'S Forge In Medieval Times, Hammer Striking Red-Hot Iron)
+
+**英文提示词：**
+
+```text
+A blacksmith's forge in medieval times, hammer striking red-hot iron on an anvil, sparks flying. The blacksmith, a burly man with soot-covered face, shapes a sword with powerful, rhythmic strikes. Fire glows in the background, casting dramatic shadows. Historical authenticity, harsh lighting, gritty realism.
+```
+
+**中文翻译：**
+
+```text
+中世纪的铁匠铺，铁匠在铁砧上敲打炽热的铁块，火花四溅。铁匠是一个结实的男人，满脸煤灰，他用有力而有节奏的锤击打造一把剑。背景中火光闪烁，投射出戏剧性的阴影。历史真实感，强烈光影，对比鲜明，写实质感。
+```
+
+**来源：** repo2/README.md#70
+
+## 例94-芭蕾舞演员在宏伟的剧院表演《天鹅湖》 (A Ballet Dancer Performing Swan Lake On A Grand Theater)
+
+**英文提示词：**
+
+```text
+A ballet dancer performing Swan Lake on a grand theater stage, spotlight following her graceful movements. She leaps and spins with perfect technique, costume flowing elegantly. Orchestra pit visible below, ornate theater architecture in the background. Classical, refined, capturing the beauty of dance.
+```
+
+**中文翻译：**
+
+```text
+一位芭蕾舞演员在宏伟的剧院舞台上表演《天鹅湖》，聚光灯跟随她优雅的动作。她完美地跳跃和旋转，服装优雅飘动。下方可见乐池，背景是精美的剧院建筑。古典、精致，捕捉舞蹈之美。
+```
+
+**来源：** repo2/README.md#71
+
+## 例95-一个科幻场景：一个空间站在轨道上 (A Science Fiction Scene Of A Space Station Orbiting A)
+
+**英文提示词：**
+
+```text
+A science fiction scene of a space station orbiting a distant planet, astronauts performing a spacewalk to repair solar panels. Earth-like planet with rings visible in the background, stars scattered across space. Realistic zero-gravity movements, futuristic technology, awe-inspiring cosmic vista.
+```
+
+**中文翻译：**
+
+```text
+一个科幻场景：一座空间站绕着一颗遥远的行星运行，宇航员正在进行太空行走以修理太阳能板。背景中可见拥有光环的类地行星，星星点缀在太空中。逼真的零重力动作，未来科技，令人惊叹的宇宙景观。
+```
+
+**来源：** repo2/README.md#72
+
+## 例96-印度村庄的季风雨，水从高处倾泻 (A Monsoon Rain In An Indian Village, Water Cascading From)
+
+**英文提示词：**
+
+```text
+A monsoon rain in an Indian village, water cascading from rooftops, children dancing and playing in the downpour. Colorful saris hang from windows, peacocks strut in the rain. The camera captures the joy and relief after a long dry season. Vibrant colors, cultural authenticity, celebration of nature.
+```
+
+**中文翻译：**
+
+```text
+印度村庄的季风雨，水从屋顶倾泻而下，孩子们在倾盆大雨中跳舞玩耍。五彩缤纷的纱丽挂在窗户上，孔雀在雨中昂首阔步。镜头捕捉到漫长干旱季节后的喜悦与宽慰。色彩鲜艳，文化真实，自然之美的庆典。
+```
+
+**来源：** repo2/README.md#73
+
+## 例97-一位糕点厨师正在装饰精美的婚礼蛋糕，挤出精细的图案 (A Pastry Chef Decorating An Elaborate Wedding Cake, Piping Intricate)
+
+**英文提示词：**
+
+```text
+A pastry chef decorating an elaborate wedding cake, piping intricate floral designs with buttercream. Extreme close-up of skilled hands working with precision. Multiple tiers, delicate sugar flowers, elegant patterns. Soft studio lighting, pristine white aesthetic, showcasing culinary artistry.
+```
+
+**中文翻译：**
+
+```text
+一位糕点师正在装饰一款精美的婚礼蛋糕，用奶油管制作复杂的花卉图案。特写镜头展示熟练的双手精准操作。多层蛋糕，精致的糖花，优雅的图案。柔和的工作室灯光，干净的白色美学，展现烹饪艺术。
+```
+
+**来源：** repo2/README.md#74
+
+## 例98-夜间火山喷发，熔岩喷射入黑暗中 (A Volcanic Eruption At Night, Lava Fountaining Into The Dark)
+
+**英文提示词：**
+
+```text
+A volcanic eruption at night, lava fountaining into the dark sky, rivers of molten rock flowing down the mountainside. Lightning crackling in the ash cloud above. The camera captures the raw power of nature, the intense heat creating a red-orange glow. Epic, dramatic, showcasing nature's fury.
+```
+
+**中文翻译：**
+
+```text
+夜晚的火山喷发，熔岩喷向黑暗的天空，熔化的岩石如河流般流下山坡。上方的火山灰云中闪电噼啪作响。镜头捕捉到大自然的原始力量，强烈的热量散发出红橙色的光芒。史诗般的、戏剧性的，展示了自然的愤怒。
+```
+
+**来源：** repo2/README.md#75
+
+## 例99-一只蜂鸟在一朵鲜红的扶桑花上吸食花蜜，翅膀 (A Hummingbird Feeding From A Vibrant Red Hibiscus Flower, Wings)
+
+**英文提示词：**
+
+```text
+A hummingbird feeding from a vibrant red hibiscus flower, wings beating so fast they're a blur. Extreme slow-motion captures the intricate details: iridescent feathers, long curved beak, droplets of nectar. Shallow depth of field, tropical garden background, macro wildlife photography.
+```
+
+**中文翻译：**
+
+```text
+一只蜂鸟正在从鲜艳的红色芙蓉花中吸取花蜜，翅膀拍打得如此快速，以至于呈现模糊效果。极慢动作捕捉到精细的细节：闪光的羽毛、长而弯曲的喙、花蜜的水滴。浅景深，热带花园背景，微距野生动物摄影。
+```
+
+**来源：** repo2/README.md#76
+
+## 例100-维多利亚时代的侦探在雾气弥漫的伦敦街道上，煤气灯下 (A Victorian-Era Detective In A Foggy London Street, Gas Lamps)
+
+**英文提示词：**
+
+```text
+A Victorian-era detective in a foggy London street, gas lamps casting eerie glows. The detective in a long coat and top hat examines clues with a magnifying glass. Horse-drawn carriages pass in the background, cobblestone streets wet from rain. Mysterious, atmospheric, Sherlock Holmes aesthetic.
+```
+
+**中文翻译：**
+
+```text
+维多利亚时代的侦探在雾气弥漫的伦敦街头，煤气灯投射出诡异的光晕。侦探身穿长外套和高顶礼帽，手持放大镜仔细检查线索。马车从背景经过，鹅卵石街道因雨水而湿滑。神秘而富有氛围，充满福尔摩斯的美学风格。
+```
+
+**来源：** repo2/README.md#77
+
+## 例101-一位跑酷运动员在城市丛林中穿梭，跃过屋顶 (A Parkour Athlete Navigating An Urban Jungle, Leaping Between Rooftops)
+
+**英文提示词：**
+
+```text
+A parkour athlete navigating an urban jungle, leaping between rooftops, vaulting over obstacles, scaling walls. The camera follows with smooth gimbal movements, capturing the fluid athleticism and daring jumps. Sunset lighting, cityscape background, adrenaline and freedom.
+```
+
+**中文翻译：**
+
+```text
+一位跑酷运动员在城市丛林中穿梭，跳跃屋顶，跨越障碍，攀爬墙壁。镜头随着稳定器平稳移动，捕捉流畅的运动技巧和大胆的跳跃。夕阳的光线，城市景观背景，充满肾上腺素和自由感。
+```
+
+**来源：** repo2/README.md#78
+
+## 例102-玻璃吹制工在塑形熔融玻璃，收集发光的橙色玻璃 (A Glassblower Shaping Molten Glass, Gathering Glowing Orange Glass On)
+
+**英文提示词：**
+
+```text
+A glassblower shaping molten glass, gathering glowing orange glass on a blowpipe, shaping it with tools and breath. The glass transforms from shapeless blob to elegant vase. The furnace glows intensely in the background. Craftsmanship, artistic process, mesmerizing transformation.
+```
+
+**中文翻译：**
+
+```text
+一位吹玻璃工正在塑造熔融的玻璃，将炽热的橙色玻璃聚集在吹管上，用工具和气息进行塑形。玻璃从无定形的块状物变成优雅的花瓶。背景中的熔炉散发出强烈的光芒。工艺、艺术过程、令人着迷的转变。
+```
+
+**来源：** repo2/README.md#79
+
+## 例103-夜晚的生物发光海湾，数百万微小生物发光 (A Bioluminescent Bay At Night, Millions Of Tiny Organisms Glowing)
+
+**英文提示词：**
+
+```text
+A bioluminescent bay at night, millions of tiny organisms glowing blue with every movement in the water. A kayak glides through, leaving a trail of ethereal light. Stars reflected on the water's surface. Magical, surreal, capturing one of nature's most stunning phenomena.
+```
+
+**中文翻译：**
+
+```text
+夜晚的生物发光海湾，数百万微小生物在水中每一次运动中发出蓝光。一只皮划艇滑过，留下神秘的光迹。星光映在水面上。神奇、超现实，捕捉到了大自然最惊艳的奇观之一。
+```
+
+**来源：** repo2/README.md#80
+
+## 例104-冰岛的冰洞，蓝色冰川冰形成，光线 (An Ice Cave In Iceland, Blue Glacial Ice Formations, Light)
+
+**英文提示词：**
+
+```text
+An ice cave in Iceland, blue glacial ice formations, light filtering through translucent walls. A lone explorer with a headlamp examines the intricate ice structures. The cave appears otherworldly, with icicles and frozen patterns. Cold color palette, natural wonder, sense of exploration.
+```
+
+**中文翻译：**
+
+```text
+冰岛的冰洞，蓝色的冰川冰层形成，光线透过半透明的墙壁。一个戴着头灯的孤独探险者仔细观察复杂的冰结构。洞穴看起来如同异世界，挂着冰柱和冻结的图案。冷色调，自然奇观，探索感十足。
+```
+
+**来源：** repo2/README.md#81
+
+## 例105-日本的传统茶道，双手小心地倒抹茶 (A Traditional Tea Ceremony In Japan, Hands Carefully Pouring Matcha)
+
+**英文提示词：**
+
+```text
+A traditional tea ceremony in Japan, hands carefully pouring matcha, whisking in a precise ritual. Steam rises from the bowl, tatami mats visible, minimalist room with shoji screens. Meditative, focusing on mindfulness and tradition. Soft natural lighting, peaceful atmosphere.
+```
+
+**中文翻译：**
+
+```text
+日本的传统茶道，双手小心地倒入抹茶，按照精确的仪式搅拌。茶碗上升起蒸汽，榻榻米清晰可见，简约的房间里有障子屏风。沉思冥想，专注于正念和传统。柔和的自然光，宁静的氛围。
+```
+
+**来源：** repo2/README.md#82
+
+## 例106-从前排座位看游乐园的过山车 (A Roller Coaster At An Amusement Park From A Front-Seat)
+
+**英文提示词：**
+
+```text
+A roller coaster at an amusement park from a front-seat POV, climbing the first hill then plunging down. Riders' hands raised, screaming in excitement. The track twists and loops, with quick cuts showing different perspectives. Thrilling, visceral, capturing the rush of the ride.
+```
+
+**中文翻译：**
+
+```text
+从正座视角看到的游乐园过山车，缓缓爬上第一座坡，然后骤然下坠。乘客举起双手，尖叫着表达兴奋。铁轨盘旋环绕，快速切换展示不同视角。惊险刺激，身临其境，捕捉游乐体验的快感。
+```
+
+**来源：** repo2/README.md#83
+
+## 例107-一位钟表匠在修理一块古董怀表，微小的齿轮和 (A Watchmaker Repairing An Antique Pocket Watch, Tiny Gears And)
+
+**英文提示词：**
+
+```text
+A watchmaker repairing an antique pocket watch, tiny gears and springs visible under a magnifying lamp. Delicate tools manipulate microscopic components. The craftsmanship and patience required for the intricate work is evident. Close-up, detailed, appreciation for precision engineering.
+```
+
+**中文翻译：**
+
+```text
+一位钟表匠正在修理一块古董怀表，放大灯下可以看到微小的齿轮和弹簧。精致的工具在操作微型零件。精细工作的工艺和耐心显而易见。特写镜头，细节丰富，体现对精密工程的赞赏。
+```
+
+**来源：** repo2/README.md#84
+
+## 例108-牧羊人带领一群羊穿过起伏的绿色草地 (A Shepherd Leading A Flock Of Sheep Across Rolling Green)
+
+**英文提示词：**
+
+```text
+A shepherd leading a flock of sheep across rolling green hills at sunset, herding dog running alongside. Ancient stone walls divide the pastoral landscape. The shepherd's weathered face tells stories of a life connected to the land. Peaceful, timeless, rural lifestyle.
+```
+
+**中文翻译：**
+
+```text
+一位牧羊人在落日下带领羊群穿过起伏的绿丘，牧羊犬在旁边奔跑。古老的石墙将田园景观分隔开来。牧羊人饱经风霜的面庞讲述着与土地紧密相连的生活故事。宁静、永恒的乡村生活方式。
+```
+
+**来源：** repo2/README.md#85
+
+## 例109-时尚T台秀，模特自信地走在舞台上 (A Fashion Runway Show, Models Walking Confidently Down The Catwalk)
+
+**英文提示词：**
+
+```text
+A fashion runway show, models walking confidently down the catwalk in avant-garde designs. Photographers' flashes create bursts of light, audience members lean forward in their seats. The clothing is bold and artistic, pushing boundaries. High fashion, glamorous, artistic expression.
+```
+
+**中文翻译：**
+
+```text
+一场时尚T台秀，模特们自信地走在前卫设计的T台上。摄影师的闪光灯闪烁不息，观众们前倾着身体观看。服装大胆且富有艺术感，突破常规。高端时尚，充满魅力，艺术的表达。
+```
+
+**来源：** repo2/README.md#86
+
+## 例110-一个陶工在轮子上，用双手塑造湿泥 (A Potter At A Wheel, Hands Shaping Wet Clay Into)
+
+**英文提示词：**
+
+```text
+A potter at a wheel, hands shaping wet clay into a vessel. The wheel spins steadily as the pot takes form, rising and expanding under skilled fingers. Clay splatter, water glistening, focused expression. The process is meditative and tactile. Artisan craft, earthy aesthetic.
+```
+
+**中文翻译：**
+
+```text
+陶工在转盘上，用双手将湿泥塑造成器皿。转盘稳稳地旋转，陶器在熟练的手指下渐渐成型、升起并扩展。泥浆飞溅，水光闪烁，神情专注。这个过程既冥想又富有触感。手工艺，质朴美学。
+```
+
+**来源：** repo2/README.md#87
+
+## 例111-绿色北极光在冰冻的挪威峡湾上空的展现 (A Northern Lights Display Over A Frozen Norwegian Fjord, Green)
+
+**英文提示词：**
+
+```text
+A Northern Lights display over a frozen Norwegian fjord, green and purple auroras dancing across the night sky. A small cabin with warm light glowing from windows sits by the shore. Snow-covered mountains reflected in still water. Breathtaking, magical, natural wonder.
+```
+
+**中文翻译：**
+
+```text
+挪威冰封峡湾上空的极光表演，绿色和紫色的极光在夜空中舞动。一座小木屋坐落在海岸边，窗户透出温暖的光。被雪覆盖的群山倒映在平静的水面上。令人叹为观止、充满魔力的自然奇观。
+```
+
+**来源：** repo2/README.md#88
+
+## 例112-一位优雅餐厅的侍酒师，正在摇晃酒杯中的葡萄酒 (A Sommelier In An Elegant Restaurant, Swirling Wine In A)
+
+**英文提示词：**
+
+```text
+A sommelier in an elegant restaurant, swirling wine in a glass, examining color and clarity. Close-up of wine being poured, legs flowing down the glass. The sommelier savors the aroma, then tastes thoughtfully. Sophisticated, refined, appreciation of wine culture.
+```
+
+**中文翻译：**
+
+```text
+一位优雅餐厅的侍酒师在酒杯中旋转葡萄酒，观察颜色和清澈度。特写镜头显示葡萄酒被倒入酒杯，酒液顺着杯壁流下。侍酒师细细品味香气，然后沉思地品尝。充满精致、优雅，体现对葡萄酒文化的欣赏。
+```
+
+**来源：** repo2/README.md#89
+
+## 例113-一位街头艺术家在人行道上创作巨大的粉笔画 (A Street Artist Creating A Massive Chalk Drawing On Pavement)
+
+**英文提示词：**
+
+```text
+A street artist creating a massive chalk drawing on pavement, aerial view shows the incredible detail and scale. Passersby stop to watch and photograph. The artwork is a trompe-l'oeil creating illusion of 3D depth. Creative, impressive, temporary art.
+```
+
+**中文翻译：**
+
+```text
+一位街头艺术家在人行道上创作巨大的粉笔画，航拍视角展示了令人难以置信的细节和规模。路人停下观看并拍照。这件作品是一幅欺骗眼睛的画作，营造出三维深度的错觉。富有创意、令人印象深刻且短暂的艺术作品。
+```
+
+**来源：** repo2/README.md#90
+
+## 例114-一只蝴蝶从蛹中破茧而出，翅膀缓缓展开 (A Butterfly Emerging From Its Chrysalis, Wings Slowly Unfurling And)
+
+**英文提示词：**
+
+```text
+A butterfly emerging from its chrysalis, wings slowly unfurling and drying. Time-lapse captures the transformation from cramped cocoon to fully formed butterfly. Dewdrops on leaves, morning light, delicate wings displaying vibrant patterns. Natural metamorphosis, rebirth, beauty of nature.
+```
+
+**中文翻译：**
+
+```text
+一只蝴蝶从蛹中破茧而出，翅膀缓缓展开并干燥。延时摄影记录了从狭小茧到完全成形的蝴蝶的转变。叶子上的露珠，晨光，纤细的翅膀展现出鲜艳的图案。自然的蜕变、重生、大自然的美丽。
+```
+
+**来源：** repo2/README.md#91
+
+## 例115-巧克力制造商调温巧克力，倒入光亮的黑巧克力 (A Chocolate Maker Tempering Chocolate, Pouring Glossy Dark Chocolate Into)
+
+**英文提示词：**
+
+```text
+A chocolate maker tempering chocolate, pouring glossy dark chocolate into molds. Steam rises as hot chocolate meets cold marble. The finished products are perfect bonbons with shiny shells. The scene captures the precision and artistry of chocolate making. Indulgent, luxurious, culinary craft.
+```
+
+**中文翻译：**
+
+```text
+一位巧克力大师正在调温巧克力，将光亮的黑巧克力倒入模具中。当热巧克力遇到冷理石时，蒸汽升腾。完成的作品是外壳光亮的完美巧克力糖。这个场景展现了巧克力制作的精准与艺术性。令人沉醉、奢华、体现烹饪工艺。
+```
+
+**来源：** repo2/README.md#92
+
+## 例116-堪萨斯小麦田上空翻滚的雷暴，乌云翻腾 (A Thunderstorm Rolling Over Kansas Wheat Fields, Dark Clouds Churning)
+
+**英文提示词：**
+
+```text
+A thunderstorm rolling over Kansas wheat fields, dark clouds churning, lightning bolts striking. Wind whips through golden wheat, creating waves across the landscape. A barn and windmill stand resilient. The power and drama of Midwest weather. Epic, dramatic, natural forces.
+```
+
+**中文翻译：**
+
+```text
+一场雷暴席卷堪萨斯的麦田，乌云翻滚，闪电劈落。风吹过金色的麦田，在大地上掀起波浪。一座谷仓和风车矗立，表现出坚韧。中西部天气的力量与戏剧性。史诗般、戏剧化的自然力量。
+```
+
+**来源：** repo2/README.md#93
+
+## 例117-一位书法家用毛笔和墨水创作汉字，每一笔都精心书写 (A Calligrapher Creating Chinese Characters With Brush And Ink, Each)
+
+**英文提示词：**
+
+```text
+A calligrapher creating Chinese characters with brush and ink, each stroke deliberate and flowing. Black ink on white rice paper, the characters taking shape with artistic flair. Focus on the brush tip, ink spreading into the paper fibers. Meditative, artistic, cultural tradition.
+```
+
+**中文翻译：**
+
+```text
+一位书法家用毛笔和墨水书写汉字，每一笔都是深思熟虑且流畅的。黑色墨汁在白色宣纸上渗开，字形逐渐显现出艺术的风采。重点在毛笔尖，墨水渗入纸的纤维。充满冥想感、艺术气息以及文化传统。
+```
+
+**来源：** repo2/README.md#94
+
+## 例118-潜入马里亚纳海沟的深海潜水器，灯光照亮 (A Deep Sea Submersible Descending Into The Mariana Trench, Lights)
+
+**英文提示词：**
+
+```text
+A deep sea submersible descending into the Mariana Trench, lights illuminating bizarre deep-sea creatures. Bioluminescent jellyfish, translucent fish with oversized eyes, strange formations on the ocean floor. The darkness and pressure create an alien environment. Scientific exploration, mysterious, otherworldly.
+```
+
+**中文翻译：**
+
+```text
+一艘深海潜水器正在马里亚纳海沟下潜，灯光照亮了奇异的深海生物。发光的水母、透明且眼睛异常大的鱼、海底的奇特地貌。黑暗和高压创造出一个陌生的环境。科学探索，神秘，异世界般的景象。
+```
+
+**来源：** repo2/README.md#95
+
+## 例119-黄昏时的摩洛哥集市，商贩们出售香料、纺织品等 (A Moroccan Souk At Dusk, Vendors Selling Spices, Textiles, And)
+
+**英文提示词：**
+
+```text
+A Moroccan souk at dusk, vendors selling spices, textiles, and lanterns. Colorful fabrics hang overhead, filtering golden sunlight. Shoppers haggle and browse, the air filled with scents of cumin and mint tea. Bustling, exotic, sensory-rich cultural scene.
+```
+
+**中文翻译：**
+
+```text
+黄昏时分的摩洛哥集市，商贩们出售香料、纺织品和灯笼。五彩斑斓的布料悬挂在上方，过滤着金色的阳光。顾客讨价还价，四处浏览，空气中弥漫着孜然和薄荷茶的香气。熙熙攘攘、充满异域风情、感官丰富的文化场景。
+```
+
+**来源：** repo2/README.md#96
+
+## 例120-慢动作滑板特技，运动员正在做踢翻动作 (A Skateboarding Trick In Slow Motion, Athlete Performing A Kickflip)
+
+**英文提示词：**
+
+```text
+A skateboarding trick in slow motion, athlete performing a kickflip over a gap. Focus on the board rotating, shoes guiding the flip, concentration on the skater's face. Urban skate park setting, graffiti walls, friends cheering. Youth culture, skill, determination.
+```
+
+**中文翻译：**
+
+```text
+慢动作滑板技巧，运动员在空隙上表演踢板翻转。重点是滑板旋转、鞋子引导翻板、滑板者脸上的专注表情。城市滑板公园场景，涂鸦墙壁，朋友们加油助威。青春文化、技巧、决心。
+```
+
+**来源：** repo2/README.md#97
+
+## 例121-蜂巢剖面图，成千上万的蜜蜂有序地工作 (A Beehive In Cross-Section, Thousands Of Bees Working In Organized)
+
+**英文提示词：**
+
+```text
+A beehive in cross-section, thousands of bees working in organized chaos. The queen surrounded by attendants, workers building honeycomb, foragers returning with pollen. The intricate social structure of the colony is visible. Educational, fascinating, natural engineering.
+```
+
+**中文翻译：**
+
+```text
+蜂巢的剖面图，成千上万的蜜蜂在有序的混乱中工作。蜂后被侍蜂团团围住，工蜂在建造蜂巢，采集蜜粉的蜜蜂归巢。蜂群复杂的社会结构清晰可见。具有教育意义，令人着迷，自然工程的杰作。
+```
+
+**来源：** repo2/README.md#98
+
+## 例122-一位弗拉明戈舞者在聚光灯下，红色裙子旋转飞舞 (A Flamenco Dancer In A Spotlight, Red Dress Swirling As)
+
+**英文提示词：**
+
+```text
+A flamenco dancer in a spotlight, red dress swirling as she stamps and spins. Guitarist strums passionately in the background, hands clapping rhythm. The dancer's expression is intense, embodying the emotion of the music. Spanish culture, passionate, dramatic performance.
+```
+
+**中文翻译：**
+
+```text
+一位弗拉明戈舞者站在聚光灯下，红色裙摆随着她的踩踏和旋转翻飞。吉他手在背景中热情地弹奏，手拍节奏。舞者的表情强烈，体现了音乐的情感。西班牙文化，充满激情，戏剧性的表演。
+```
+
+**来源：** repo2/README.md#99
+
+## 例123-日出时的热气球节，数十个五彩缤纷的气球 (A Hot Air Balloon Festival At Sunrise, Dozens Of Colorful)
+
+**英文提示词：**
+
+```text
+A hot air balloon festival at sunrise, dozens of colorful balloons inflating and lifting off. Aerial shots show the patchwork of balloons floating over countryside. Passengers wave from baskets, burners roar, creating pillars of flame. Joyful, colorful, celebration of flight.
+```
+
+**中文翻译：**
+
+```text
+日出时的热气球节，数十个五颜六色的气球正在充气和起飞。航拍镜头展示了气球在乡村上空漂浮的拼布景象。乘客在篮子里挥手，燃烧器轰鸣，喷出火柱。充满喜悦、色彩斑斓、庆祝飞行的场景。
+```
+
+**来源：** repo2/README.md#100
+
+## 📚 来源
+
+- [zhangchenchen/awesome_sora2_prompt](https://github.com/zhangchenchen/awesome_sora2_prompt)
+- [AI-Tool-List/Sora2-Prompt](https://github.com/AI-Tool-List/Sora2-Prompt)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
           - text-to-image/gpt/gpt-image-1.md
   - Text-to-Video:
       - text-to-video/cinematic-trailer.md
+      - text-to-video/awesome-sora2.md
 theme:
   name: material
   custom_dir: overrides


### PR DESCRIPTION
## Summary
- replace the Sora 2 English prompt collection with all 123 prompts from the two source repositories and list their origins
- mirror the full catalog in the Chinese page with every English prompt and fresh Simplified Chinese translations

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68e07d00d3108333afe0ed5b9554f871