### PR TITLE
Add automatic AdSense injection across documentation pages

### DIFF
--- a/docs/assets/javascripts/ads.js
+++ b/docs/assets/javascripts/ads.js
@@ -1,0 +1,81 @@
+(function () {
+  const AD_SLOT = "2056784980";
+  const AD_CLIENT = "ca-pub-7296634171837358";
+  const MAX_RENDER_ATTEMPTS = 10;
+  const RETRY_DELAY = 500;
+
+  function renderAdWithRetry(attempt = 0) {
+    if (attempt > MAX_RENDER_ATTEMPTS) {
+      return;
+    }
+
+    if (window.adsbygoogle && Array.isArray(window.adsbygoogle)) {
+      try {
+        window.adsbygoogle.push({});
+      } catch (error) {
+        console.warn("Adsense rendering error", error);
+      }
+      return;
+    }
+
+    setTimeout(() => renderAdWithRetry(attempt + 1), RETRY_DELAY);
+  }
+
+  function createAdElement(container) {
+    const adElement = document.createElement("ins");
+    adElement.className = "adsbygoogle page-ad";
+    adElement.style.display = "block";
+    adElement.setAttribute("data-ad-client", AD_CLIENT);
+    adElement.setAttribute("data-ad-slot", AD_SLOT);
+    adElement.setAttribute("data-ad-format", "auto");
+    adElement.setAttribute("data-full-width-responsive", "true");
+
+    const heading = container.querySelector("h1, h2, h3, h4, h5, h6");
+
+    if (heading && heading.parentNode) {
+      if (heading.nextSibling) {
+        heading.parentNode.insertBefore(adElement, heading.nextSibling);
+      } else {
+        heading.parentNode.appendChild(adElement);
+      }
+    } else {
+      container.insertBefore(adElement, container.firstChild);
+    }
+
+    return adElement;
+  }
+
+  function ensureAd() {
+    const container = document.querySelector("article.md-content__inner");
+
+    if (!container) {
+      return;
+    }
+
+    let adElement = container.querySelector(
+      `ins.adsbygoogle[data-ad-slot="${AD_SLOT}"]`
+    );
+
+    if (!adElement) {
+      adElement = createAdElement(container);
+    }
+
+    if (
+      adElement &&
+      !adElement.dataset.adsbygoogleStatus &&
+      !adElement.getAttribute("data-adsbygoogle-status")
+    ) {
+      renderAdWithRetry();
+    }
+  }
+
+  function setup() {
+    ensureAd();
+  }
+
+  if (window.document$ && typeof window.document$.subscribe === "function") {
+    window.document$.subscribe(setup);
+  } else {
+    document.addEventListener("DOMContentLoaded", setup);
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ theme:
     repo: fontawesome/brands/github
 extra_css:
   - stylesheets/code.css
+extra_javascript:
+  - assets/javascripts/ads.js
 extra:
   analytics:
     provider: google


### PR DESCRIPTION
## Summary
- add a reusable client-side helper that injects the homepage AdSense block into every documentation page and retries rendering until the library is ready
- register the helper in the MkDocs configuration so the script is bundled with every build

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68e10dbeed44833397dd59c7e1d40f7e