### PR TITLE
Add Eimu - online GPT Image 2 & Nano Banana Pro generator

### DIFF
--- a/docs/similar-sites.en.md
+++ b/docs/similar-sites.en.md
@@ -77,7 +77,7 @@ Here are some excellent prompt-related resource websites that provide additional
 - [Kimi Practice Form - Feishu Sheet](https://kh18s6uvdi.feishu.cn/share/base/view/shrcnm6JDJzeITUAee3sbsipUee)
 - [WaytoAGI Prompts - Feishu Wiki](https://waytoagi.feishu.cn/wiki/Q5mXww4rriujFFkFQOzc8uIsnah?table=tbldSgFt2xNUDNAz&view=vewo2g2ktO)
 - [Text-to-Image Examples](https://catjourney.life/)
-- [Emu](https://image.tinchak0207.xyz) - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
+- [Eimu](https://eimu.art) - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
 - [Curated Prompt Collections](https://dye87dshnj.feishu.cn/wiki/Hv6GwDhoji1ttikSUBUcAjHSnMe)
 - [Moonshot AI Official](https://www.moonshot.cn)
 

--- a/docs/similar-sites.en.md
+++ b/docs/similar-sites.en.md
@@ -77,6 +77,7 @@ Here are some excellent prompt-related resource websites that provide additional
 - [Kimi Practice Form - Feishu Sheet](https://kh18s6uvdi.feishu.cn/share/base/view/shrcnm6JDJzeITUAee3sbsipUee)
 - [WaytoAGI Prompts - Feishu Wiki](https://waytoagi.feishu.cn/wiki/Q5mXww4rriujFFkFQOzc8uIsnah?table=tbldSgFt2xNUDNAz&view=vewo2g2ktO)
 - [Text-to-Image Examples](https://catjourney.life/)
+- [Emu](https://image.tinchak0207.xyz) - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
 - [Curated Prompt Collections](https://dye87dshnj.feishu.cn/wiki/Hv6GwDhoji1ttikSUBUcAjHSnMe)
 - [Moonshot AI Official](https://www.moonshot.cn)
 

--- a/docs/similar-sites.md
+++ b/docs/similar-sites.md
@@ -77,7 +77,7 @@
 - [Kimi 实践在线表单 - 飞书表格](https://kh18s6uvdi.feishu.cn/share/base/view/shrcnm6JDJzeITUAee3sbsipUee)
 - [WaytoAGI Prompts - 飞书文档](https://waytoagi.feishu.cn/wiki/Q5mXww4rriujFFkFQOzc8uIsnah?table=tbldSgFt2xNUDNAz&view=vewo2g2ktO)
 - [文生图实例](https://catjourney.life/)
-- [Emu](https://image.tinchak0207.xyz) - 在线生成 GPT Image 2 / Nano Banana Pro 图片，登录即用，不用中转站、不用申请 API Key
+- [Eimu](https://eimu.art) - 在线生成 GPT Image 2 / Nano Banana Pro 图片，登录即用，不用中转站、不用申请 API Key
 - [一些优质 Prompt 精选站](https://dye87dshnj.feishu.cn/wiki/Hv6GwDhoji1ttikSUBUcAjHSnMe)
 - [月之暗面官方](https://www.moonshot.cn)
 

--- a/docs/similar-sites.md
+++ b/docs/similar-sites.md
@@ -77,6 +77,7 @@
 - [Kimi 实践在线表单 - 飞书表格](https://kh18s6uvdi.feishu.cn/share/base/view/shrcnm6JDJzeITUAee3sbsipUee)
 - [WaytoAGI Prompts - 飞书文档](https://waytoagi.feishu.cn/wiki/Q5mXww4rriujFFkFQOzc8uIsnah?table=tbldSgFt2xNUDNAz&view=vewo2g2ktO)
 - [文生图实例](https://catjourney.life/)
+- [Emu](https://image.tinchak0207.xyz) - 在线生成 GPT Image 2 / Nano Banana Pro 图片，登录即用，不用中转站、不用申请 API Key
 - [一些优质 Prompt 精选站](https://dye87dshnj.feishu.cn/wiki/Hv6GwDhoji1ttikSUBUcAjHSnMe)
 - [月之暗面官方](https://www.moonshot.cn)
 


### PR DESCRIPTION
Add [Eimu](https://eimu.art) to the 拓展资源 (Additional Resources) section of similar-sites.

Online image generation tool for GPT Image 2 / Nano Banana Pro style images - sign in, type a prompt, download. No relay station setup or API key required. Offers OpenAI-compatible generation API and MCP integration.

Docs: https://eimu.art/docs