### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ To join the WeChat community, scan the QR code below or search WeChat ID `frytea
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=songtianlun%2Fawesome-prompts&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#songtianlun/awesome-prompts&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=songtianlun/awesome-prompts&type=timeline&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=songtianlun/awesome-prompts&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=songtianlun/awesome-prompts&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=songtianlun/awesome-prompts&type=timeline&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=songtianlun/awesome-prompts&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=songtianlun/awesome-prompts&type=timeline&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken because it relies on the GitHub stargazer API, which has become restricted. This change migrates the chart to a working alternative data source that needs no API token, so the star history graph displays correctly again. The wrapping link and the chart image have both been updated to the new address.